### PR TITLE
Update TIP-6: Tagged data payload

### DIFF
--- a/tips/TIP-0006/tip-0006.md
+++ b/tips/TIP-0006/tip-0006.md
@@ -150,26 +150,24 @@ The following criteria defines whether the message passes the syntactical valida
 
 While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this RFC. The following table lists all currently specified payloads that can be part of a message and links to their specification. The _indexation payload_ will be specified here as an example:
 
-| Payload Name | Type Value | TIP                                                                                                           |
-| ------------ | ---------- | ------------------------------------------------------------------------------------------------------------- |
-| Transaction  | 0          | [TIP-7](../TIP-0007/tip-0007.md) |
-| Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)     |
-| Indexation   | 2          | [TIP-6](#indexation-payload)                                                                               |
+| Payload Name  | Type Value | TIP                              |
+| ------------- | ---------- | -------------------------------- |
+| Transaction   | 0          | [TIP-7](../TIP-0007/tip-0007.md) |
+| Milestone     | 1          | [TIP-8](../TIP-0008/tip-0008.md) |
+| Tagged Data   | 5          | [TIP-6](#tagged-data-payload)    |
 
-### Indexation payload
+### Tagged data payload
 
-This payload allows the addition of an index to the encapsulating message, as well as some arbitrary data. Nodes will expose an API that allows to query messages by index.
+This payload allows the addition of arbitrary data to the encapsulationg messages. An optional tag can be used to categorize the data. It is important to note that the tag is not considered by the protocol, it serves just as a marker for second layer applications.
 
-The structure of the indexation payload is as follows:
+| Name         | Type                  | Description                                          |
+| ------------ | --------------------- | ---------------------------------------------------- |
+| Payload Type | uint32                | Set to *value 5* to denote an _Tagged Data Payload_. |
+| Tag Length   | uint8                 | The length of the following tag field in bytes.      |
+| Tag          | ByteArray[Tag Length] | The tag of the data.                                 |
+| Data         | ByteArray             | Binary data.                                         |
 
-| Name         | Type                    | Description                                                   |
-| ------------ | ----------------------- | ------------------------------------------------------------- |
-| Payload Type | uint32                  | Set to <b>value 2</b> to denote an <i>Indexation Payload</i>. |
-| Index Length | uint16                  | The length of the following index field in bytes.             |
-| Index        | ByteArray[Index Length] | The index key of the message                                  |
-| Data         | ByteArray               | Binary data.                                                  |
-
-Note that `Index` field must be at least 1 byte and not longer than 64 bytes for the payload to be valid. The `Data` may have a length of 0.
+*Syntactic validation*: `Tag Length` must not be larger than `Max Tag Length`. When `Tag Length` is 0, the `Tag` has length 0 and is omitted.
 
 ## Example
 
@@ -180,11 +178,11 @@ Below is the full serialization of a valid message with an indexation payload. T
 - Parents (64-byte):
   - `210fc7bb818639ac48a4c6afa2f1581a8b9525e20fda68927f2b2ff836f73578`
   - `db0fa54c29f7fd928d92ca43f193dee47f591549f597a811c8fa67ab031ebd9c`
-- Payload Length (4-byte): `19000000` (25)
-- Payload (25-byte):
-  - Payload Type (4-byte): `02000000` (2)
-  - Index Length (2-byte): `0400` (4)
-  - Index (4-byte): `494f5441` ("IOTA")
+- Payload Length (4-byte): `18000000` (24)
+- Payload (24-byte):
+  - Payload Type (4-byte): `05000000` (5)
+  - Tag Length (1-byte): `04` (4)
+  - Tag (4-byte): `494f5441` ("IOTA")
   - Data (15-byte):
     - Length (4-byte): `0b000000` (11)
     - Data (11-byte): `68656c6c6f20776f726c64` ("hello world")

--- a/tips/TIP-0006/tip-0006.md
+++ b/tips/TIP-0006/tip-0006.md
@@ -11,7 +11,8 @@ created: 2020-07-28
 ---
 
 + Changelog:
-  + ([iotaledger/tips#0037](https://github.com/iotaledger/tips/pull/0037)) Fixed internal links
+  + ([iotaledger/tips#37](https://github.com/iotaledger/tips/pull/0037)) Fixed internal links
+  + ([iotaledger/tips#50](https://github.com/iotaledger/tips/pull/50)) Replace Indexation with Tagged Data Payload
 
 # Summary
 


### PR DESCRIPTION
This PR removes the _Indexation Payload_ which was used to index data in the nodes by a _Tagged Data Payload_ that is not indexed.
This PR modifies the existing TIP-6.