### PR TITLE
TIP-23 Tagged Data Payload

### DIFF
--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -24,18 +24,17 @@ The most flexible way to extend an existing object is by the addition of arbitra
 
 The following table describes the serialization of a _Tagged Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
 
-| Name         | Type                  | Description                                          |
-| ------------ | --------------------- | ---------------------------------------------------- |
-| Payload Type | uint32                | Set to *value 5* to denote an _Tagged Data Payload_. |
-| Tag Length   | uint8                 | The length of the following tag field in bytes.      |
-| Tag          | ByteArray[Tag Length] | The tag of the data.                                 |
-| Data         | ByteArray             | Binary data.                                         |
+| Name         | Type              | Description                                              |
+|--------------|-------------------|----------------------------------------------------------|
+| Payload Type | uint32            | Set to *value 5* to denote an _Tagged Data Payload_.     |
+| Tag          | (uint8)ByteArray  | The tag of the data. A leading uint8 denotes its length. |
+| Data         | (uint32)ByteArray | Binary data. A leading uint32 denotes its length.        |
 
 It is important to note that `Tag` is not considered by the protocol, it just serves as a marker for second layer applications.
 
 ## Syntactic Validation
 
-- `Tag Length` must not be larger than `Max Tag Length`. When `Tag Length` is 0, the `Tag` has length 0 and is omitted.
+- `length(Tag)` must not be larger than [`Max Tag Length`](../TIP-0022/tip-0022.md).
 - Given the type and length information, the _Tagged Data Payload_ must consume the entire byte array of the `Payload` field of the encapsulating object.
 
 # Rationale

--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -1,7 +1,7 @@
 ---
 tip: 23
 title: Tagged Data Payload
-description: Payload for arbitrary data
+description: Block payload for arbitrary data
 author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
 discussions-to: https://github.com/iotaledger/tips/pull/54
 status: Draft

--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -3,7 +3,7 @@ tip: 23
 title: Tagged Data Payload
 description: Payload for arbitrary data
 author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/50
+discussions-to: https://github.com/iotaledger/tips/pull/54
 status: Draft
 type: Standards
 layer: Core

--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -1,0 +1,47 @@
+---
+tip: 23
+title: Tagged Data Payload
+description: Payload for arbitrary data
+author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
+discussions-to: https://github.com/iotaledger/tips/pull/44
+status: Draft
+type: Standards
+layer: Core
+created: 2022-01-24
+---
+
+# Abstract
+
+The payload concept offers a very flexible way to combine and encapsulate information in the IOTA protocol. This document proposes a basic payload type that allows the addition of arbitrary data.
+
+# Motivation
+
+The most flexible way to extend an existing object is by the addition of arbitrary data. This payload provides a way to do just that. An optional tag can be used to categorize the data.
+
+# Specification
+
+## Serialized Layout
+
+The following table describes the serialization of a _Tagged Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
+
+| Name         | Type                  | Description                                          |
+| ------------ | --------------------- | ---------------------------------------------------- |
+| Payload Type | uint32                | Set to *value 5* to denote an _Tagged Data Payload_. |
+| Tag Length   | uint8                 | The length of the following tag field in bytes.      |
+| Tag          | ByteArray[Tag Length] | The tag of the data.                                 |
+| Data         | ByteArray             | Binary data.                                         |
+
+It is important to note that `Tag` is not considered by the protocol, it just serves as a marker for second layer applications.
+
+## Syntactic Validation
+
+- `Tag Length` must not be larger than `Max Tag Length`. When `Tag Length` is 0, the `Tag` has length 0 and is omitted.
+- Given the type and length information, the _Tagged Data Payload_ must consume the entire byte array of the `Payload` field of the encapsulating object.
+
+# Rationale
+
+As the tag is not considered by the protocol, it could also be removed completely. However, Legacy IOTA and Chrysalis supported sending of arbitrary data indexed with a tag. Thus, in order to simplify the migration of second layer applications using these protocols, the optional `Tag` has been added which can be used in a similar manner.
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -3,7 +3,7 @@ tip: 23
 title: Tagged Data Payload
 description: Payload for arbitrary data
 author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/44
+discussions-to: https://github.com/iotaledger/tips/pull/50
 status: Draft
 type: Standards
 layer: Core


### PR DESCRIPTION
This PR creates a new TIP containing the Tagged Data Payload.
It supersedes #50 

[Rendered Version](https://github.com/Wollac/protocol-rfcs/blob/tagged-data/tips/TIP-0023/tip-0023.md)