### PR TITLE
TIP-24 Tangle Block (Stardust)

### DIFF
--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -136,10 +136,10 @@ The following criteria defines whether the message passes the syntactical valida
 While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a message and links to their specification:
 
 | Payload Name | Type Value | TIP                                     |
-| ------------ | ---------- | --------------------------------------- |
-| Transaction  | 0          | [TIP-7](../TIP-0007/tip-0007.md)        |
+|--------------|------------|-----------------------------------------|
 | Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)        |
 | Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
+| Transaction  | 6          | [draft TIP-20](../TIP-0020/tip-0020.md) |
 
 ## Example
 

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -141,22 +141,9 @@ While messages without a payload, i.e. `Payload Length` set to zero, are valid, 
 | Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)        |
 | Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
 
-### Tagged data payload
-
-This payload allows the addition of arbitrary data to the encapsulationg messages. An optional tag can be used to categorize the data. It is important to note that the tag is not considered by the protocol, it serves just as a marker for second layer applications.
-
-| Name         | Type                  | Description                                          |
-| ------------ | --------------------- | ---------------------------------------------------- |
-| Payload Type | uint32                | Set to *value 5* to denote an _Tagged Data Payload_. |
-| Tag Length   | uint8                 | The length of the following tag field in bytes.      |
-| Tag          | ByteArray[Tag Length] | The tag of the data.                                 |
-| Data         | ByteArray             | Binary data.                                         |
-
-*Syntactic validation*: `Tag Length` must not be larger than `Max Tag Length`. When `Tag Length` is 0, the `Tag` has length 0 and is omitted.
-
 ## Example
 
-Below is the full serialization of a valid message with a tagged data payload. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
+Below is the full serialization of a valid message with a _Tagged Data Payload_. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
 
 - Network ID (8-byte): `0000000000000000` (0)
 - Parents Count (1-byte): `02` (2)

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -137,9 +137,9 @@ While messages without a payload, i.e. `Payload Length` set to zero, are valid, 
 
 | Payload Name | Type Value | TIP                                     |
 |--------------|------------|-----------------------------------------|
-| Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)        |
 | Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
 | Transaction  | 6          | [draft TIP-20](../TIP-0020/tip-0020.md) |
+| Milestone    | 7          | [draft TIP-29](../TIP-0029/tip-0029.md) |
 
 ## Example
 

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -1,0 +1,183 @@
+---
+tip: 24
+title: Tangle Message
+description: Generalization of the Tangle transaction concept
+author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
+discussions-to: https://github.com/iotaledger/tips/pull/51
+status: Draft
+type: Standards
+layer: Core
+created: 2022-01-24
+---
+
+# Abstract
+
+The Tangle is the graph data structure behind IOTA. In the current IOTA protocol, the vertices of the Tangle are represented by transactions. This document proposes an abstraction of this idea where the vertices are generalized *messages*, which then contain the transactions or other structures that are processed by the IOTA protocol. Just as before, each message directly approves other messages, which are known as _parents_.
+
+The messages can contain payloads. These are core payloads that will be processed by all nodes as part of the IOTA protocol. Some payloads may have other nested payloads embedded inside. Hence, parsing is done layer by layer.
+
+# Motivation
+
+To better understand this layered design, consider the Internet Protocol (IP), for example: There is an Ethernet frame that contains an IP payload. This in turn contains a TCP packet that encapsulates an HTTP payload. Each layer has a certain responsibility and once this responsibility is completed, we move on to the next layer.
+
+The same is true with how messages are parsed. The outer layer of the message enables the mapping of the message to a vertex in the Tangle and allow us to perform some basic validation. The next layer may be a transaction that mutates the ledger state, and one layer further may provide some extra functionality on the transactions to be used by applications.
+
+By making it possible to add and exchange payloads, an architecture is being created that can easily be extended to accommodate future needs.
+
+# Specification
+
+## Message ID
+
+The *Message ID* is the [BLAKE2b-256](https://tools.ietf.org/html/rfc7693) hash of the entire serialized message.
+
+## Serialized Layout
+
+The following table describes the serialization of a _Message_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>Network ID</td>
+    <td>uint64</td>
+        <td>Network identifier. This field denotes whether the message was meant for mainnet, testnet, or a private net. It also marks what protocol rules apply to the message. Usually, it will be set to the first 8 bytes of the BLAKE2b-256 hash of the <code>Network String</code>.</td>
+  </tr>
+  <tr>
+    <td>Parents Count</td>
+    <td>uint8</td>
+    <td>The number of messages that are directly approved.</td>
+  </tr>
+  <tr>
+    <td valign="top">Parents <code>anyOf</code></td>
+    <td colspan="2">
+      <details>
+        <summary>Parent</summary>
+        <blockquote>
+          References another directly approved message.
+        </blockquote>
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>Message ID</td>
+            <td>ByteArray[32]</td>
+            <td>The Message ID of the parent.</td>
+          </tr>
+        </table>
+      </details>
+    </td>
+  </tr>
+  <tr>
+    <td>Payload Length</td>
+    <td>uint32</td>
+    <td>The length of the following payload in bytes. A length of 0 means no payload will be attached.</td>
+  </tr>
+  <tr>
+    <td valign="top">Payload <code>oneOf</code></td>
+    <td colspan="2">
+      <details open="true">
+        <summary>Generic Payload</summary>
+        <blockquote>
+          An outline of a generic payload
+        </blockquote>
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>Payload Type</td>
+            <td>uint32</td>
+            <td>
+              The type of the payload. It will instruct the node how to parse the fields that follow.
+            </td>
+          </tr>
+          <tr>
+            <td>Data Fields</td>
+            <td>ANY</td>
+            <td>A sequence of fields, where the structure depends on <code>Payload Type</code>.</td>
+          </tr>
+        </table>
+      </details>
+  <tr>
+    <td>Nonce</td>
+    <td>uint64</td>
+    <td>The nonce which lets this message fulfill the PoW requirement.</td>
+  </tr>
+</table>
+
+## Syntactical validation
+
+The following criteria defines whether the message passes the syntactical validation:
+
+- The total length of the serialized message must not exceed `Max Message Length`.
+- `Network ID` must match the first 8 bytes of the BLAKE2b-256 hash of the `Network String` parameter.
+- Parents:
+  - `Parents Count` must be at least 1 and not larger than `Max Parents Count`.
+  - `Parents` must be sorted in lexicographical order.
+  - Each `Message ID` must be unique.
+- Payload (if present):
+  - `Payload Type` must match one of the values described under [Payloads](#payloads).
+  - `Data fields` must be correctly parsable in the context of the `Payload Type`.
+  - The payload itself must pass syntactic validation.
+- `Nonce` must be a valid solution of the message PoW as described in [TIP-12](../TIP-0012/tip-0012.md). The resulting PoW score must be larger or equal `Min PoW Score`.
+- There must be no trailing bytes after all message fields have been parsed.
+
+## Payloads
+
+While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this RFC. The following table lists all currently specified payloads that can be part of a message and links to their specification:
+
+| Payload Name | Type Value | TIP                                     |
+| ------------ | ---------- | --------------------------------------- |
+| Transaction  | 0          | [TIP-7](../TIP-0007/tip-0007.md)        |
+| Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)        |
+| Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
+
+### Tagged data payload
+
+This payload allows the addition of arbitrary data to the encapsulationg messages. An optional tag can be used to categorize the data. It is important to note that the tag is not considered by the protocol, it serves just as a marker for second layer applications.
+
+| Name         | Type                  | Description                                          |
+| ------------ | --------------------- | ---------------------------------------------------- |
+| Payload Type | uint32                | Set to *value 5* to denote an _Tagged Data Payload_. |
+| Tag Length   | uint8                 | The length of the following tag field in bytes.      |
+| Tag          | ByteArray[Tag Length] | The tag of the data.                                 |
+| Data         | ByteArray             | Binary data.                                         |
+
+*Syntactic validation*: `Tag Length` must not be larger than `Max Tag Length`. When `Tag Length` is 0, the `Tag` has length 0 and is omitted.
+
+## Example
+
+Below is the full serialization of a valid message with an indexation payload. The index is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
+
+- Network ID (8-byte): `0000000000000000` (0)
+- Parents Count (1-byte): `02` (2)
+- Parents (64-byte):
+  - `210fc7bb818639ac48a4c6afa2f1581a8b9525e20fda68927f2b2ff836f73578`
+  - `db0fa54c29f7fd928d92ca43f193dee47f591549f597a811c8fa67ab031ebd9c`
+- Payload Length (4-byte): `18000000` (24)
+- Payload (24-byte):
+  - Payload Type (4-byte): `05000000` (5)
+  - Tag Length (1-byte): `04` (4)
+  - Tag (4-byte): `494f5441` ("IOTA")
+  - Data (15-byte):
+    - Length (4-byte): `0b000000` (11)
+    - Data (11-byte): `68656c6c6f20776f726c64` ("hello world")
+- Nonce (8-byte): `ce6d000000000000` (28110)
+
+# Rationale and alternatives
+
+Instead of creating a layered approach, we could have simply created a flat transaction message that is tailored to mutate the ledger state, and try to fit all the use cases there. For example, with the indexed data use case, we could have filled some section of the transaction with that particular data. Then, this transaction would not correspond to a ledger mutation but instead only carry data.
+
+This approach seems less extensible. It might have made sense if we had wanted to build a protocol that is just for ledger mutating transactions, but we want to be able to extend the protocol to do more than that.
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -114,8 +114,9 @@ The following table describes the serialization of a _Message_ following the not
   </tr>
 </table>
 
-## Syntactical validation
+## Syntactic validation
 
+The Tangle can only contain syntactically valid messages. Invalid must be rejected by the node.
 The following criteria defines whether the message passes the syntactical validation:
 
 - The total length of the serialized message must not exceed `Max Message Length`.

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -80,7 +80,7 @@ The following table describes the serialization of a _Message_ following the not
     <td>The length of the following payload in bytes. A length of 0 means no payload will be attached.</td>
   </tr>
   <tr>
-    <td valign="top">Payload <code>oneOf</code></td>
+    <td valign="top">Payload <code>optOneOf</code></td>
     <td colspan="2">
       <details open="true">
         <summary>Generic Payload</summary>

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -116,7 +116,7 @@ The following table describes the serialization of a _Block_ following the notat
 
 ## Syntactic validation
 
-The Tangle can only contain syntactically valid blocks. Invalid must be rejected by the node.
+The Tangle can only contain syntactically valid blocks. Invalid blocks must be rejected by the node.
 The following criteria defines whether the block passes the syntactic validation:
 
 - The total length of the serialized block must not exceed `Max Block Length`.

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -3,7 +3,7 @@ tip: 24
 title: Tangle Message
 description: Generalization of the Tangle transaction concept
 author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/51
+discussions-to: https://github.com/iotaledger/tips/pull/55
 status: Draft
 type: Standards
 layer: Core

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -7,6 +7,7 @@ discussions-to: https://github.com/iotaledger/tips/pull/55
 status: Draft
 type: Standards
 layer: Core
+replaces: 6
 created: 2022-01-24
 ---
 
@@ -132,7 +133,7 @@ The following criteria defines whether the message passes the syntactical valida
 
 ## Payloads
 
-While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this RFC. The following table lists all currently specified payloads that can be part of a message and links to their specification:
+While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a message and links to their specification:
 
 | Payload Name | Type Value | TIP                                     |
 | ------------ | ---------- | --------------------------------------- |
@@ -155,7 +156,7 @@ This payload allows the addition of arbitrary data to the encapsulationg message
 
 ## Example
 
-Below is the full serialization of a valid message with an indexation payload. The index is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
+Below is the full serialization of a valid message with a tagged data payload. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
 
 - Network ID (8-byte): `0000000000000000` (0)
 - Parents Count (1-byte): `02` (2)

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -142,7 +142,7 @@ It is important to note, that the actual parsing and validating of a payload can
 While blocks without a payload, i.e. `Payload Length` set to zero, are valid, such blocks do not contain any information. As such, blocks usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a block and links to their specification:
 
 | Payload Name | Type Value | TIP                               | PoW Condition                  |
-| ------------ | ---------- | --------------------------------- | ------------------------------ |
+|--------------|------------|-----------------------------------|--------------------------------|
 | No Payload   | -          | -                                 | PoW score ≥ `Min PoW Score`    |
 | Tagged Data  | 5          | [TIP-23](../TIP-0023/tip-0023.md) | PoW score ≥ `Min PoW Score`    |
 | Transaction  | 6          | [TIP-20](../TIP-0020/tip-0020.md) | PoW score ≥ `Min PoW Score`    |
@@ -152,7 +152,7 @@ While blocks without a payload, i.e. `Payload Length` set to zero, are valid, su
 
 Below is the full serialization of a valid block with a _Tagged Data Payload_. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
 
-- Protocol Version (1-byte): `00` (0)
+- Protocol Version (1-byte): `02` (2)
 - Parents Count (1-byte): `02` (2)
 - Parents (64-byte):
   - `210fc7bb818639ac48a4c6afa2f1581a8b9525e20fda68927f2b2ff836f73578`
@@ -160,8 +160,9 @@ Below is the full serialization of a valid block with a _Tagged Data Payload_. T
 - Payload Length (4-byte): `18000000` (24)
 - Payload (24-byte):
   - Payload Type (4-byte): `05000000` (5)
-  - Tag Length (1-byte): `04` (4)
-  - Tag (4-byte): `494f5441` ("IOTA")
+  - Tag (5-byte):
+    - Length (1-byte): `04` (4)
+    - Tag (4-byte): `494f5441` ("IOTA")
   - Data (15-byte):
     - Length (4-byte): `0b000000` (11)
     - Data (11-byte): `68656c6c6f20776f726c64` ("hello world")

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -21,7 +21,7 @@ The blocks can contain payloads. These are core payloads that will be processed 
 
 To better understand this layered design, consider the Internet Protocol (IP), for example: There is an Ethernet frame that contains an IP payload. This in turn contains a TCP packet that encapsulates an HTTP payload. Each layer has a certain responsibility and once this responsibility is completed, we move on to the next layer.
 
-The same is true with how blocks are parsed. The outer layer of the block enables the mapping of the block to a vertex in the Tangle and allow us to perform some basic validation. The next layer may be a transaction that mutates the ledger state, and one layer further may provide some extra functionality on the transactions to be used by applications.
+The same is true with how blocks are parsed. The outer layer of the block enables the mapping of the block to a vertex in the Tangle and allows us to perform some basic validation. The next layer may be a transaction that mutates the ledger state, and one layer further may provide some extra functionality on the transactions to be used by applications.
 
 By making it possible to add and exchange payloads, an architecture is being created that can easily be extended to accommodate future needs.
 
@@ -117,7 +117,7 @@ The following table describes the serialization of a _Block_ following the notat
 ## Syntactic validation
 
 The Tangle can only contain syntactically valid blocks. Invalid must be rejected by the node.
-The following criteria defines whether the block passes the syntactical validation:
+The following criteria defines whether the block passes the syntactic validation:
 
 - The total length of the serialized block must not exceed `Max Block Length`.
 - `Protocol Version` must match the `Protocol Version` config parameter of the node.
@@ -127,20 +127,26 @@ The following criteria defines whether the block passes the syntactical validati
   - Each `Block ID` must be unique.
 - Payload (if present):
   - `Payload Type` must match one of the values described under [Payloads](#payloads).
-  - `Data fields` must be correctly parsable in the context of the `Payload Type`.
+  - `Data Fields` must be correctly parsable in the context of the `Payload Type`.
   - The payload itself must pass syntactic validation.
-- `Nonce` must be a valid solution of the block PoW as described in [TIP-12](../TIP-0012/tip-0012.md). The resulting PoW score must be larger or equal `Min PoW Score`.
+- `Nonce` must be valid with respect to the PoW condition described under [Payloads](#payloads). The PoW score itself is computed according to [TIP-12](../TIP-0012/tip-0012.md).
 - There must be no trailing bytes after all block fields have been parsed.
+  
+### PoW validation
+
+The PoW that needs to be performed for each block protects the network against denial-of-service attacks where in a short time too many blocks are issued for the nodes to process. As the processing time of a block heavily depends on the contained payload, the PoW check can also depend on the `Payload Type` and is described under [Payloads](#payloads).
+It is important to note, that the actual parsing and validating of a payload can be computationally expensive. Thus, it is recommended to first parse the block with all its fields including `Payload Type` (but not parsing or validating the actual payload `Data Fields`). Now, simple syntactic validation steps &ndash; including PoW validation &ndash; can be performed and invalid blocks already filtered out before the payload is validated. With this approach, payload-based PoW validation is not significantly more expensive than payload-agnostic validation.
 
 ## Payloads
 
 While blocks without a payload, i.e. `Payload Length` set to zero, are valid, such blocks do not contain any information. As such, blocks usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a block and links to their specification:
 
-| Payload Name | Type Value | TIP                                                                                                               |
-|--------------|------------|-------------------------------------------------------------------------------------------------------------------|
-| Tagged Data  | 5          | [draft TIP-23](https://github.com/Wollac/protocol-rfcs/blob/tagged-data/tips/TIP-0023/tip-0023.md)                |
-| Transaction  | 6          | [draft TIP-20](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md)                           |
-| Milestone    | 7          | [draft TIP-29](https://github.com/iotaledger/tips/blob/milestone-with-signature-blocks/tips/TIP-0029/tip-0029.md) |
+| Payload Name | Type Value | TIP                               | PoW Condition                  |
+| ------------ | ---------- | --------------------------------- | ------------------------------ |
+| No Payload   | -          | -                                 | PoW score ≥ `Min PoW Score`    |
+| Tagged Data  | 5          | [TIP-23](../TIP-0023/tip-0023.md) | PoW score ≥ `Min PoW Score`    |
+| Transaction  | 6          | [TIP-20](../TIP-0020/tip-0020.md) | PoW score ≥ `Min PoW Score`    |
+| Milestone    | 7          | [TIP-29](../TIP-0029/tip-0029.md) | `nonce` = `0x0000000000000000` |
 
 ## Example
 

--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -1,6 +1,6 @@
 ---
 tip: 24
-title: Tangle Message
+title: Tangle Block
 description: Generalization of the Tangle transaction concept
 author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>
 discussions-to: https://github.com/iotaledger/tips/pull/55
@@ -13,27 +13,27 @@ created: 2022-01-24
 
 # Abstract
 
-The Tangle is the graph data structure behind IOTA. In the current IOTA protocol, the vertices of the Tangle are represented by transactions. This document proposes an abstraction of this idea where the vertices are generalized *messages*, which then contain the transactions or other structures that are processed by the IOTA protocol. Just as before, each message directly approves other messages, which are known as _parents_.
+The Tangle is the graph data structure behind IOTA. In the legacy IOTA protocol, the vertices of the Tangle are represented by transactions. This document proposes an abstraction of this idea where the vertices are generalized *blocks*, which then contain the transactions or other structures that are processed by the IOTA protocol. Just as before, each block directly approves other blocks, which are known as _parents_.
 
-The messages can contain payloads. These are core payloads that will be processed by all nodes as part of the IOTA protocol. Some payloads may have other nested payloads embedded inside. Hence, parsing is done layer by layer.
+The blocks can contain payloads. These are core payloads that will be processed by all nodes as part of the IOTA protocol. Some payloads may have other nested payloads embedded inside. Hence, parsing is done layer by layer.
 
 # Motivation
 
 To better understand this layered design, consider the Internet Protocol (IP), for example: There is an Ethernet frame that contains an IP payload. This in turn contains a TCP packet that encapsulates an HTTP payload. Each layer has a certain responsibility and once this responsibility is completed, we move on to the next layer.
 
-The same is true with how messages are parsed. The outer layer of the message enables the mapping of the message to a vertex in the Tangle and allow us to perform some basic validation. The next layer may be a transaction that mutates the ledger state, and one layer further may provide some extra functionality on the transactions to be used by applications.
+The same is true with how blocks are parsed. The outer layer of the block enables the mapping of the block to a vertex in the Tangle and allow us to perform some basic validation. The next layer may be a transaction that mutates the ledger state, and one layer further may provide some extra functionality on the transactions to be used by applications.
 
 By making it possible to add and exchange payloads, an architecture is being created that can easily be extended to accommodate future needs.
 
 # Specification
 
-## Message ID
+## Block ID
 
-The *Message ID* is the [BLAKE2b-256](https://tools.ietf.org/html/rfc7693) hash of the entire serialized message.
+The *Block ID* is the [BLAKE2b-256](https://tools.ietf.org/html/rfc7693) hash of the entire serialized block.
 
 ## Serialized Layout
 
-The following table describes the serialization of a _Message_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
+The following table describes the serialization of a _Block_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
 
 <table>
   <tr>
@@ -44,12 +44,12 @@ The following table describes the serialization of a _Message_ following the not
   <tr>
     <td>Protocol Version</td>
     <td>uint8</td>
-        <td> Protocol version number of the message.</td>
+        <td> Protocol version number of the block.</td>
   </tr>
   <tr>
     <td>Parents Count</td>
     <td>uint8</td>
-    <td>The number of messages that are directly approved.</td>
+    <td>The number of blocks that are directly approved.</td>
   </tr>
   <tr>
     <td valign="top">Parents <code>anyOf</code></td>
@@ -57,7 +57,7 @@ The following table describes the serialization of a _Message_ following the not
       <details>
         <summary>Parent</summary>
         <blockquote>
-          References another directly approved message.
+          References another directly approved block.
         </blockquote>
         <table>
           <tr>
@@ -66,9 +66,9 @@ The following table describes the serialization of a _Message_ following the not
             <th>Description</th>
           </tr>
           <tr>
-            <td>Message ID</td>
+            <td>Block ID</td>
             <td>ByteArray[32]</td>
-            <td>The Message ID of the parent.</td>
+            <td>The Block ID of the parent.</td>
           </tr>
         </table>
       </details>
@@ -110,41 +110,41 @@ The following table describes the serialization of a _Message_ following the not
   <tr>
     <td>Nonce</td>
     <td>uint64</td>
-    <td>The nonce which lets this message fulfill the PoW requirement.</td>
+    <td>The nonce which lets this block fulfill the PoW requirement.</td>
   </tr>
 </table>
 
 ## Syntactic validation
 
-The Tangle can only contain syntactically valid messages. Invalid must be rejected by the node.
-The following criteria defines whether the message passes the syntactical validation:
+The Tangle can only contain syntactically valid blocks. Invalid must be rejected by the node.
+The following criteria defines whether the block passes the syntactical validation:
 
-- The total length of the serialized message must not exceed `Max Message Length`.
+- The total length of the serialized block must not exceed `Max Block Length`.
 - `Protocol Version` must match the `Protocol Version` config parameter of the node.
 - Parents:
   - `Parents Count` must be at least 1 and not larger than `Max Parents Count`.
   - `Parents` must be sorted in lexicographical order.
-  - Each `Message ID` must be unique.
+  - Each `Block ID` must be unique.
 - Payload (if present):
   - `Payload Type` must match one of the values described under [Payloads](#payloads).
   - `Data fields` must be correctly parsable in the context of the `Payload Type`.
   - The payload itself must pass syntactic validation.
-- `Nonce` must be a valid solution of the message PoW as described in [TIP-12](../TIP-0012/tip-0012.md). The resulting PoW score must be larger or equal `Min PoW Score`.
-- There must be no trailing bytes after all message fields have been parsed.
+- `Nonce` must be a valid solution of the block PoW as described in [TIP-12](../TIP-0012/tip-0012.md). The resulting PoW score must be larger or equal `Min PoW Score`.
+- There must be no trailing bytes after all block fields have been parsed.
 
 ## Payloads
 
-While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a message and links to their specification:
+While blocks without a payload, i.e. `Payload Length` set to zero, are valid, such blocks do not contain any information. As such, blocks usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a block and links to their specification:
 
-| Payload Name | Type Value | TIP                                     |
-|--------------|------------|-----------------------------------------|
-| Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
-| Transaction  | 6          | [draft TIP-20](../TIP-0020/tip-0020.md) |
-| Milestone    | 7          | [draft TIP-29](../TIP-0029/tip-0029.md) |
+| Payload Name | Type Value | TIP                                                                                                               |
+|--------------|------------|-------------------------------------------------------------------------------------------------------------------|
+| Tagged Data  | 5          | [draft TIP-23](https://github.com/Wollac/protocol-rfcs/blob/tagged-data/tips/TIP-0023/tip-0023.md)                |
+| Transaction  | 6          | [draft TIP-20](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md)                           |
+| Milestone    | 7          | [draft TIP-29](https://github.com/iotaledger/tips/blob/milestone-with-signature-blocks/tips/TIP-0029/tip-0029.md) |
 
 ## Example
 
-Below is the full serialization of a valid message with a _Tagged Data Payload_. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
+Below is the full serialization of a valid block with a _Tagged Data Payload_. The tag is the "IOTA" ASCII string and the data is the "hello world" ASCII string. Bytes are expressed as hexadecimal numbers.
 
 - Protocol Version (1-byte): `00` (0)
 - Parents Count (1-byte): `02` (2)
@@ -163,7 +163,7 @@ Below is the full serialization of a valid message with a _Tagged Data Payload_.
 
 # Rationale and alternatives
 
-Instead of creating a layered approach, we could have simply created a flat transaction message that is tailored to mutate the ledger state, and try to fit all the use cases there. For example, with the indexed data use case, we could have filled some section of the transaction with that particular data. Then, this transaction would not correspond to a ledger mutation but instead only carry data.
+Instead of creating a layered approach, we could have simply created a flat transaction block that is tailored to mutate the ledger state, and try to fit all the use cases there. For example, with the tagged data use case, we could have filled some section of the transaction with that particular data. Then, this transaction would not correspond to a ledger mutation but instead only carry data.
 
 This approach seems less extensible. It might have made sense if we had wanted to build a protocol that is just for ledger mutating transactions, but we want to be able to extend the protocol to do more than that.
 


### PR DESCRIPTION
A new version of [TIP-6](https://github.com/iotaledger/tips/blob/main/tips/TIP-0006/tip-0006.md) that removes the _Indexation Payload_ and instead adds the _Tagged Data Payload_ as a supported payload.

Renames former _Messages_ to _Blocks_ to align with IOTA 2.0 terminology.

This supersedes #50 

[Rendered Version](https://github.com/Wollac/protocol-rfcs/blob/tangle-message-data/tips/TIP-0024/tip-0024.md)