### PR TITLE
TIP-25 Node Core REST API

### DIFF
--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1665,6 +1665,7 @@ components:
         type: 7
         index: 15465
         timestamp: 1602227215
+        protocolVersion: 2
         previousMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         parents:
          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
@@ -2480,6 +2481,9 @@ components:
         timestamp:
           type: integer
           description: The Unix timestamp at which the milestone was issued. The unix timestamp is specified in seconds.
+        protocolVersion:
+          type: integer
+          description: Protocol version of the Milestone Payload and its encapsulating block.
         previousMilestoneId:
           type: string
           description: The Milestone ID of the milestone with Index Number - 1.
@@ -2513,6 +2517,7 @@ components:
         - type
         - index
         - timestamp
+        - protocolVersion
         - previousMilestoneId
         - parents
         - inclusionMerkleRoot

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1992,8 +1992,6 @@ components:
       required:
         - type
         - amount
-        - nativeTokens
-        - featureBlocks
         - unlockConditions
 
     AliasOutput:
@@ -2049,12 +2047,9 @@ components:
       required:
         - type
         - amount
-        - nativeTokens
         - aliasId
         - stateIndex
         - foundryCounter
-        - featureBlocks
-        - immutableFeatureBlocks
         - unlockConditions
 
     FoundryOutput:
@@ -2106,13 +2101,10 @@ components:
       required:
         - type
         - amount
-        - nativeTokens
         - serialNumber
         - tokenTag
         - tokenScheme
         - unlockConditions
-        - featureBlocks
-        - immutableFeatureBlocks
 
     NFTOutput:
       description: escribes an NFT output, a globally unique token with metadata attached.
@@ -2161,11 +2153,8 @@ components:
       required:
         - type
         - amount
-        - nativeTokens
         - nftId
         - unlockConditions
-        - featureBlocks
-        - immutableFeatureBlocks
 
     NativeToken:
       description: A native token and its balance in the output.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1725,6 +1725,9 @@ components:
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex-encoded number with 0x prefix.
+      required:
+        - tokenId
+        - amount
 
     Ed25519Address:
       description: The Ed25519 address.
@@ -1776,6 +1779,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
 
     ImmutableAliasAddressUnlockCondition:
       description: Can be unlocked by unlocking the permanent alias address.
@@ -1787,6 +1793,9 @@ components:
         address:
           oneOf:
             - $ref: '#/components/schemas/AliasAddress'
+      required:
+        - type
+        - address
 
     StorageDepositReturnUnlockCondition:
       description: Can be unlocked by depositing return amount to return address via an output that only has Address Unlock Condition.
@@ -1802,6 +1811,10 @@ components:
         returnAmount:
           type: string
           description: Amount of IOTA tokens the consuming transaction should deposit to the address defined in Return Address. Plain string encoded number.
+      required:
+        - type
+        - returnAddress
+        - returnAmount
 
     TimelockUnlockCondition:
       description: Can be unlocked if the confirming milestone has a >= Milestone Index/Unixt Timestamp.
@@ -1815,6 +1828,8 @@ components:
         unixTime:
           type: integer
           description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
+      required:
+        - type
 
     ExpirationUnlockCondition:
       description: Defines a milestone index and/or unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the milestone index and/or unix time, only Return Address can unlock it.
@@ -1833,6 +1848,9 @@ components:
         unixTime:
           type: integer
           description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
+      required:
+        - type
+        - returnAddress
 
     StateControllerAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.
@@ -1845,6 +1863,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
 
     GovernorAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.
@@ -1857,6 +1878,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
 
     SenderBlock:
       description: Identifies the validated sender of the output.
@@ -1869,6 +1893,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - sender
 
     IssuerBlock:
       description: Identifies the validated issuer of the UTXO state machine (alias/NFT).
@@ -1876,11 +1903,14 @@ components:
         type:
           type: integer
           description: Set to value 1 to denote an Issuer Block.
-        sender:
+        issuer:
           oneOf:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - issuer
 
     MetadataBlock:
       description: Defines metadata (arbitrary binary data) that will be stored in the output.
@@ -1891,6 +1921,9 @@ components:
         data:
           type: string
           description: Hex-encoded binary data with 0x prefix.
+      required:
+        - type
+        - data
 
     TagBlock:
       description: Defines an indexation tag to which the output can be indexed by additional node plugins.
@@ -1901,6 +1934,9 @@ components:
         tag:
           type: string
           description: Hex-encoded binary indexation tag with 0x prefix.
+      required:
+        - type
+        - tag
 
     SimpleTokenScheme:
       description: Defines the simple supply control scheme of native tokens. Tokens can be minted by the foundry without additional restrictions as long as maximum supply is requested and circulating supply is not negative.
@@ -2015,13 +2051,18 @@ components:
           description: 256-bit hash based on the message IDs of all the not-ignored state-mutating transactions referenced by the milestone. Hex-encoded with 0x prefix.
         nextPoWScore:
           type: number
+          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
         nextPoWScoreMilestoneIndex:
+          description: The milestone index at which the PoW score changes to NextPoWScore.
           type: number
-        publicKeys:
-          type: array
-          items:
-            type: string
-          description: An array of public keys to validate the signatures. The keys must be in lexicographical order. Hex-encoded with 0x prefix.
+        metadata:
+          type: string
+          description: Hex-encoded binary data with 0x prefix.
+        receipt:
+          type: object
+          description: The inner payload of the milestone. Can be nil or a Receipt.
+          oneOf:
+            - $ref: '#/components/schemas/ReceiptPayload'
         signatures:
           type: array
           items:
@@ -2221,6 +2262,9 @@ components:
     ReceiptPayload:
       description: Contains a receipt and the index of the milestone which contained the receipt.
       properties:
+        type:
+          type: integer
+          description: Type identifier of a receipt payload (3).
         migratedAt:
           type: integer
         final:
@@ -2236,6 +2280,7 @@ components:
         - final
         - funds
         - transaction
+        - type
 
     MigratedFundsEntry:
       properties:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1263,7 +1263,7 @@ components:
 
     get-tips-response-example:
       value:
-        tipBlockIds:
+        tips:
           - "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           - "0x78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"
 
@@ -2979,13 +2979,13 @@ components:
     TipsResponse:
       description: Returns tips that are ideal for attaching a block.
       properties:
-        tipBlockIds:
+        tips:
           type: array
           items:
             type: string
           description: The block identifiers that can be used to a attach a block to. Hex-encoded with 0x prefix.
       required:
-        - tipBlockIds
+        - tips
 
     SubmitBlockRequest:
       description: Submits a block to the node.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -64,8 +64,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InfoResponse'
               examples:
-                default:
+                IOTA:
                   $ref: '#/components/examples/get-info-response-example'
+                Shimmer:
+                  $ref: '#/components/examples/get-info-response-example-shimmer'
         '403':
           description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
           content:
@@ -1208,6 +1210,53 @@ components:
             vByteCost: 500
             vByteFactorData: 1
             vByteFactorKey: 10
+        baseToken:
+          name: "IOTA"
+          tickerSymbol: "MIOTA"
+          unit: "IOTA"
+          decimals: 0
+          subunit: null
+          useMetricPrefix: true
+        features:
+          - PoW
+        plugins:
+          - indexer/v1
+    get-info-response-example-shimmer:
+      value:
+        name: HORNET
+        version: 2.0.0-alpha8
+        status:
+          isHealthy: true
+          latestMilestone:
+            index: 480
+            timestamp: 1617802102
+            milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
+          confirmedMilestone:
+            index: 480
+            timestamp: 1617802102
+            milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
+          pruningIndex: 0
+        metrics:
+          messagesPerSecond: 17
+          referencedMessagesPerSecond: 16.8
+          referencedRate: 98.82352941176471
+        protocol:
+          networkName: shimmer-testnet
+          bech32HRP: rms
+          tokenSupply: "2779530283277761"
+          protocolVersion: 2
+          minPoWScore: 1000
+          rentStructure:
+            vByteCost: 500
+            vByteFactorData: 1
+            vByteFactorKey: 10
+        baseToken:
+          name: "Shimmer"
+          tickerSymbol: "SMR"
+          unit: "SMR"
+          decimals: 6
+          subunit: "glow"
+          useMetricPrefix: false
         features:
           - PoW
         plugins:
@@ -2865,6 +2914,27 @@ components:
                 vByteFactoKey:
                   description: Defines the factor to be used for key/lookup generating fields.
                   type: integer
+            baseToken:
+              description: Gives info about the base token the network uses.
+              properties:
+                name:
+                  type: string
+                  description: The name of the base token of the network.
+                tickerSymbol:
+                  type: string
+                  description: Ticker symbol of the token to be displayed on trading platforms.
+                unit:
+                  type: string
+                  description: The primary unit of the token.
+                decimals:
+                  type: integer
+                  description: Number of decimals the primary unit is divisible up to.
+                subunit:
+                  type: string
+                  description: The name of the smallest possible denomination of the primary unit. subunit * 10^decimals = unit
+                "useMetricPrefix":
+                  type: boolean
+                  description: Wheteher to use metric prefixes for disaplying unit.
           required:
             - networkName
             - bech32HRP
@@ -2872,6 +2942,7 @@ components:
             - protocolVersion
             - minPoWScore
             - rentStructure
+            - baseToken
         features:
           description: The features that are supported by the node. For example, a node could support the Proof-of-Work (PoW) feature, which would allow the PoW to be performed by the node itself.
           type: array

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2072,9 +2072,6 @@ components:
         serialNumber:
           type: integer
           description: The serial number of the foundry with respect to the controlling alias.
-        tokenTag:
-          type: string
-          description: Hex-encoded data with 0x prefix that is always the last 12 bytes of ID of the tokens produced by this foundry.
         tokenScheme:
           type: array
           description: Defines the supply control scheme of the tokens controlled by the foundry.
@@ -2104,7 +2101,6 @@ components:
         - type
         - amount
         - serialNumber
-        - tokenTag
         - tokenScheme
         - unlockConditions
 
@@ -2163,7 +2159,7 @@ components:
       properties:
         tokenId:
           type: string
-          description: Hex-encoded identifier with 0x prefix of the native token.
+          description: Hex-encoded identifier with 0x prefix of the native token. Same as foundryId of the controlling foundry.
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex-encoded number with 0x prefix.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1218,8 +1218,6 @@ components:
           useMetricPrefix: true
         features:
           - PoW
-        plugins:
-          - indexer/v1
     get-info-response-example-shimmer:
       value:
         name: HORNET

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -3197,23 +3197,6 @@ components:
         - milestoneId
         - amount
 
-    MilestoneResponse:
-      description: Returns information about a milestone.
-      properties:
-        index:
-          type: integer
-          description: The index number of the milestone.
-        blockId:
-          type: string
-          description: The identifier of a block which describes this milestone. Note that different blocks could describe the same milestone. Hex-encoded with 0x prefix.
-        timestamp:
-          type: integer
-          description: The timestamp of when the  milestone was issued.
-      required:
-        - index
-        - blockId
-        - timestamp
-
     UTXOChangesResponse:
       description: Returns all UTXO changes of the given milestone.
       properties:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -26,6 +26,8 @@ tags:
     description: Everything about milestones.
   - name: peers
     description: Everything about the peers of the node.
+  - name: control
+    description: Everything about controlling the node.
 paths:
   /health:
     get:
@@ -968,6 +970,157 @@ paths:
         '500':
           description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
 
+  '/api/v2/whiteflag':
+    post:
+      tags:
+        - milestones
+      summary: Computes applied and confirmed merkle route hashes for a proposed milestone.
+      description: Computes applied and confirmed merkle route hashes for a proposed milestone.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComputeWhiteFlagRequest'
+            examples:
+              default:
+                $ref: '#/components/examples/compute-whiteflag-request-example'
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComputeWhiteFlagResponse'
+              examples:
+                default:
+                  $ref: '#/components/examples/compute-whiteflag-response-example'
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  '/api/v2/control/database/prune':
+    post:
+      tags:
+        - control
+      summary: Prunes the node database.
+      description: Prunes the node database..
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PruneDatabaseRequest'
+            examples:
+              default:
+                $ref: '#/components/examples/database-prune-request-example'
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PruneDatabaseResponse'
+              examples:
+                default:
+                  $ref: '#/components/examples/database-prune-response-example'
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  '/api/v2/control/snapshot/create':
+    post:
+      tags:
+        - control
+      summary: Creates a new snapshot.
+      description: Creates a new snapshot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSnapshotRequest'
+            examples:
+              Full Snapshot:
+                $ref: '#/components/examples/create-full-snapshot-request-example'
+              Delta Snapshot:
+                $ref: '#/components/examples/create-delta-snapshot-request-example'
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSnapshotResponse'
+              examples:
+                Full Snapshot:
+                  $ref: '#/components/examples/create-full-snapshot-response-example'
+                Delta Snapshot:
+                  $ref: '#/components/examples/create-delta-snapshot-response-example'
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
 components:
   examples:
     get-info-response-example:
@@ -1548,6 +1701,48 @@ components:
             sentMilestoneRequests: 31
             sentHeartbeats: 9
             droppedPackets: 0
+
+    compute-whiteflag-request-example:
+      value:
+        index: 1560
+        timestamp: 1602227215
+        parentMessageIds:
+          - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
+          - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
+          - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
+          - "0xde9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652"
+        lastMilestoneId: "0x733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d"
+
+    compute-whiteflag-response-example:
+      value:
+        confirmedMerkleRoot: "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649"
+        appliedMerkleRoot: "0xbbffde11ef804fdbc7c8f62432937b7a00806c136eca21c54038d5a6bdd16251"
+
+    database-prune-request-example:
+      value:
+        targetDatabaseSize: 21474836480
+
+    database-prune-response-example:
+      value:
+        index: 1560
+
+    create-full-snapshot-request-example:
+      value:
+        fullIndex: 1560
+
+    create-full-snapshot-response-example:
+      value:
+        fullIndex: 1560
+        fullFilePath: "snapshots/mainnet/full_snapshot_1560.bin"
+
+    create-delta-snapshot-request-example:
+      value:
+        deltaIndex: 1000
+
+    create-delta-snapshot-response-example:
+      value:
+        deltaIndex: 1000
+        deltaFilePath: "snapshots/mainnet/delta_snapshot_1000.bin"
 
   schemas:
 
@@ -2931,3 +3126,87 @@ components:
       properties:
         allOf:
           $ref: '#/components/schemas/Peer'
+
+    ComputeWhiteFlagRequest:
+      description: Milestone info and parents to start the computation from.
+      properties:
+        index:
+          type: integer
+          description: The index of the milestone.
+        timestamp:
+          type: integer
+          description: The timestamp of the milestone.
+        parentMessageIds:
+          type: array
+          description: The hex encoded message IDs of the parents the milestone references.
+          items:
+            type: string
+        lastMilestoneId:
+          type: string
+          description: The hex encoded milestone ID of the previous milestone.
+      required:
+        - index
+        - timestamp
+        - parentMessageIds
+        - lastMilestoneId
+
+    ComputeWhiteFlagResponse:
+      description: Returns the computed ConfirmedMerkleRoot and AppliedMerkleRoot
+      properties:
+        confirmedMerkleRoot:
+          type: string
+          description: The hex encoded confirmed merkle tree root as a result of the white flag computation.
+        appliedMerkleRoot:
+          type: string
+          description: The hex encoded applied merkle tree root as a result of the white flag computation.
+      required:
+        - confirmedMerkleRoot
+        - appliedMerkleRoot
+
+    PruneDatabaseRequest:
+      description:  Defines the request of a prune database REST API call
+      properties:
+        index:
+          type: integer
+          description: The pruning target index.
+        depth:
+          type: integer
+          description: The pruning depth.
+        targetDatabaseSize:
+          type: string
+          description: The target size of the database in bytes.
+
+    PruneDatabaseResponse:
+      description: Defines the response of a prune database REST API call
+      properties:
+        index:
+          type: integer
+          description: The index of the snapshot.
+      required:
+        - index
+
+    CreateSnapshotRequest:
+      description: Defines the request of a create snapshots REST API call.
+      properties:
+        fullIndex:
+          type: integer
+          description: The index of the full snapshot.
+        delatIndex:
+          type: integer
+          description: The index of the delta snapshot.
+
+    CreateSnapshotResponse:
+      description: Defines the request of a create snapshots REST API call.
+      properties:
+        fullIndex:
+          type: integer
+          description: The index of the full snapshot.
+        delatIndex:
+          type: integer
+          description: The index of the delta snapshot.
+        fullFilePath:
+          type: string
+          description: The file path of the full snapshot file.
+        deltaFilePath:
+          type: string
+          description: The file path of the delta snapshot file.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1189,10 +1189,10 @@ components:
           - 3
         protocol:
           networkName: iota-testnet
-          bech32HRP: atoi
+          bech32Hrp: atoi
           tokenSupply: "2779530283277761"
           protocolVersion: 2
-          minPoWScore: 1000
+          minPowScore: 1000
           rentStructure:
             vByteCost: 500
             vByteFactorData: 1
@@ -1242,10 +1242,10 @@ components:
           - 3
         protocol:
           networkName: shimmer-testnet
-          bech32HRP: rms
+          bech32Hrp: rms
           tokenSupply: "2779530283277761"
           protocolVersion: 2
-          minPoWScore: 1000
+          minPowScore: 1000
           rentStructure:
             vByteCost: 500
             vByteFactorData: 1
@@ -2922,7 +2922,7 @@ components:
             networkName:
               type: string
               description: The Name of the network from which the networkId is derived.
-            bech32HRP:
+            bech32Hrp:
               type: string
               description: Tells whether the node supports mainnet or testnet addresses. Value `iota` indicates that the node supports mainnet addresses. Value `atoi` indicates that the node supports testnet addresses.
             tokenSupply:
@@ -2931,7 +2931,7 @@ components:
             protocolVersion:
               type: integer
               description: Protocol version used by the network.
-            minPoWScore:
+            minPowScore:
               description: The Proof-of-Work difficulty for a block to be sent over the network to mitigate spam.
               type: number
               format: float
@@ -2953,10 +2953,10 @@ components:
                 - vByteFactoKey
           required:
             - networkName
-            - bech32HRP
+            - bech32Hrp
             - tokenSupply
             - protocolVersion
-            - minPoWScore
+            - minPowScore
             - rentStructure
         pendingProtocolParameters:
           description: Pending protocol parameters.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2060,7 +2060,7 @@ components:
           description: Hex-encoded binary data with 0x prefix.
         receipt:
           type: object
-          description: The inner payload of the milestone. Can be nil or a Receipt.
+          description: The inner receipt payload of the milestone. Can be nil or a Receipt.
           oneOf:
             - $ref: '#/components/schemas/ReceiptPayload'
         signatures:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2226,22 +2226,22 @@ components:
         - returnAmount
 
     TimelockUnlockCondition:
-      description: Can be unlocked if the confirming milestone has a >= Milestone Index/Unixt Timestamp.
+      description: Can be unlocked if the confirming milestone has a >= Unix Timestamp.
       properties:
         type:
           type: integer
           description: Set to value 2 to denote an Timelock Unlock Condition.
-        milestoneIndex:
-          type: integer
-          description: The milestone index starting from which the output can be consumed.
         unixTime:
           type: integer
           description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
+          minimum: 0
+          exclusiveMinimum: true
       required:
         - type
+        - unixTime
 
     ExpirationUnlockCondition:
-      description: Defines a milestone index and/or unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the milestone index and/or unix time, only Return Address can unlock it.
+      description: Defines a unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the unix time, only Return Address can unlock it.
       properties:
         type:
           type: integer
@@ -2251,15 +2251,15 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
-        milestoneIndex:
-          type: integer
-          description: Before this milestone index, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
         unixTime:
           type: integer
           description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
+          minimum: 0
+          exclusiveMinimum: true
       required:
         - type
         - returnAddress
+        - unixTime
 
     StateControllerAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1984,14 +1984,14 @@ components:
               - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
               - $ref: '#/components/schemas/TimelockUnlockCondition'
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-              - $ref: '#/components/schemas/TagBlock'
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+              - $ref: '#/components/schemas/TagFeature'
       required:
         - type
         - amount
@@ -2032,21 +2032,21 @@ components:
             anyOf:
               - $ref: '#/components/schemas/StateControllerAddressUnlockCondition'
               - $ref: '#/components/schemas/GovernorAddressUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
-            These blocks need to be kept in future transitions of the UTXO state machine.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
+            These features need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount
@@ -2085,19 +2085,19 @@ components:
           items:
             anyOf:
               - $ref: '#/components/schemas/ImmutableAliasAddressUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/MetadataBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/MetadataFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
-            These blocks need to be kept in future transitions of the UTXO state machine.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
+            These features need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount
@@ -2132,23 +2132,23 @@ components:
               - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
               - $ref: '#/components/schemas/TimelockUnlockCondition'
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-              - $ref: '#/components/schemas/TagBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+              - $ref: '#/components/schemas/TagFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
-            These blocks need to be kept in future transitions of the UTXO state machine.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
+            These features need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount
@@ -2321,12 +2321,12 @@ components:
         - type
         - address
 
-    SenderBlock:
+    SenderFeature:
       description: Identifies the validated sender of the output.
       properties:
         type:
           type: integer
-          description: Set to value 0 to denote a Sender Block.
+          description: Set to value 0 to denote a Sender Feature.
         sender:
           oneOf:
             - $ref: '#/components/schemas/Ed25519Address'
@@ -2336,12 +2336,12 @@ components:
         - type
         - sender
 
-    IssuerBlock:
+    IssuerFeature:
       description: Identifies the validated issuer of the UTXO state machine (alias/NFT).
       properties:
         type:
           type: integer
-          description: Set to value 1 to denote an Issuer Block.
+          description: Set to value 1 to denote an Issuer Feature.
         issuer:
           oneOf:
             - $ref: '#/components/schemas/Ed25519Address'
@@ -2351,12 +2351,12 @@ components:
         - type
         - issuer
 
-    MetadataBlock:
+    MetadataFeature:
       description: Defines metadata (arbitrary binary data) that will be stored in the output.
       properties:
         type:
           type: integer
-          description: Set to value 2 to denote a Metadata Block.
+          description: Set to value 2 to denote a Metadata Feature.
         data:
           type: string
           description: Hex-encoded binary data with 0x prefix.
@@ -2364,12 +2364,12 @@ components:
         - type
         - data
 
-    TagBlock:
+    TagFeature:
       description: Defines an indexation tag to which the output can be indexed by additional node plugins.
       properties:
         type:
           type: integer
-          description: Set to value 3 to denote a Metadata Block.
+          description: Set to value 3 to denote a Tag Feature.
         tag:
           type: string
           description: Hex-encoded binary indexation tag with 0x prefix.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2967,6 +2967,7 @@ components:
         - status
         - metrics
         - protocol
+        - baseToken
         - features
         - plugins
 

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2875,6 +2875,10 @@ components:
                 - index
                 - timestamp
                 - milestoneId
+          required:
+            - isHealthy
+            - latestMilestone
+            - confirmedMilestone
         metrics:
           description: Node metrics.
           properties:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -3025,6 +3025,8 @@ components:
         nonce:
           type: string
           description: The nonce which lets this block fulfill the Proof-of-Work requirement. Hex-encoded with 0x prefix.
+      required:
+        - protocolVersion
 
     SubmitBlockResponse:
       description: Returns the block identifier of the submitted block.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1936,7 +1936,6 @@ components:
           description: The optional embedded payload.
           oneOf:
             - $ref: '#/components/schemas/TaggedDataPayload'
-          nullable: true
       required:
         - type
         - networkId
@@ -2625,6 +2624,9 @@ components:
           description: Metrics about the gossip stream with the peer.
           allOf:
             - $ref: '#/components/schemas/Metrics'
+      required:
+        - heartbeat
+        - metrics
 
     Heartbeat:
       properties:
@@ -3039,8 +3041,7 @@ components:
           description: Tells if the block could get solidified by the node or not.
         referencedByMilestoneIndex:
           type: integer
-          nullable: true
-          description: Tells which milestone references this block. If `null` the block was not referenced by a milestone yet.
+          description: Tells which milestone references this block.
         milestoneIndex:
           type: integer
           description: If set, this block can be considered as a valid milestone block. This field therefore describes the milestone index of the involved milestone. A block can be considered as a valid milestone block if the milestone payload is valid and if the referenced parents in the milestone payload do match the referenced parents in the block itself. Note it's possible to have different milestone blocks that all represent the same milestone.
@@ -3146,15 +3147,12 @@ components:
         milestoneIndexSpent:
           type: integer
           description: The milestone index at which this output was spent.
-          nullable: true
         milestoneTimestampSpent:
           type: integer
           description: The milestone timestamp this output was spent.
-          nullable: true
         transactionIdSpent:
           type: string
           description: The transaction this output was spent with. Hex-encoded with 0x prefix.
-          nullable: true
         milestoneIndexBooked:
           type: integer
           description: The milestone index at which the output was booked.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -18,8 +18,8 @@ tags:
     description: Everything about the node itself.
   - name: tangle
     description: Everything about the tangle itself.
-  - name: messages
-    description: Everything about messages.
+  - name: blocks
+    description: Everything about blocks.
   - name: UTXO
     description: Everything about UTXOs.
   - name: milestones
@@ -85,9 +85,9 @@ paths:
     get:
       tags:
         - tangle
-      summary: Returns tips that are ideal for attaching a message.
+      summary: Returns tips that are ideal for attaching a block.
       description: >-
-        Returns tips that are ideal for attaching a message. The tips can be considered as `non-lazy` and are therefore ideal for attaching a message.
+        Returns tips that are ideal for attaching a block. The tips can be considered as `non-lazy` and are therefore ideal for attaching a block.
       responses:
         '200':
           description: "Successful operation."
@@ -117,39 +117,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  /api/v2/messages:
+  /api/v2/blocks:
     post:
       tags:
-        - messages
-      summary: Submit a message.
+        - blocks
+      summary: Submit a block.
       description: >-
-        Submit a message. The node takes care of missing* fields and tries to
-        build the message. On success, the message will be stored in the Tangle.
-        This endpoint will return the identifier of the built message. *The
+        Submit a block. The node takes care of missing* fields and tries to
+        build the block. On success, the block will be stored in the Tangle.
+        This endpoint will return the identifier of the built block. *The
         node will try to auto-fill the following fields in case they are
-        missing: `protocolVersion`, `parentMessageIds`, `nonce`.
-        If `payload` is missing, the message will be built without a payload.
+        missing: `protocolVersion`, `parentBlockIds`, `nonce`.
+        If `payload` is missing, the block will be built without a payload.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubmitMessageRequest'
+              $ref: '#/components/schemas/SubmitBlockRequest'
             examples:
-              Full message with Tagged Data Payload:
-                $ref: "#/components/examples/post-tagged-data-message-request-example-full"
-              Minimal Message with Tagged Data Payload:
-                $ref: "#/components/examples/post-tagged-data-message-request-example-minimal"
-              Full message with Transaction Payload:
+              Full block with Tagged Data Payload:
+                $ref: "#/components/examples/post-tagged-data-block-request-example-full"
+              Minimal Block with Tagged Data Payload:
+                $ref: "#/components/examples/post-tagged-data-block-request-example-minimal"
+              Full block with Transaction Payload:
                 $ref: >-
-                  #/components/examples/post-transaction-message-request-example-full
-              Minimal Message with Transaction Payload:
+                  #/components/examples/post-transaction-block-request-example-full
+              Minimal Block with Transaction Payload:
                 $ref: >-
-                  #/components/examples/post-transaction-message-request-example-minimal
+                  #/components/examples/post-transaction-block-request-example-minimal
           application/vnd.iota.serializer-v1:
             schema:
               type: string
               format: binary
-              description: message in raw binary format
+              description: block in raw binary format
         required: true
       responses:
         '201':
@@ -157,13 +157,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubmitMessageResponse'
+                $ref: '#/components/schemas/SubmitBlockResponse'
               examples:
                 default:
-                  $ref: '#/components/examples/post-messages-response-example'
+                  $ref: '#/components/examples/post-blocks-response-example'
           headers:
             Location:
-              description: The messageId of the newly created message.
+              description: The blockId of the newly created block.
               schema:
                 type: string
         '400':
@@ -190,47 +190,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/messages/{messageId}':
+  '/api/v2/blocks/{blockId}':
     get:
       tags:
-        - messages
-      summary: Returns message data as JSON by its identifier.
+        - blocks
+      summary: Returns block data as JSON by its identifier.
       description: >-
-        Find a message by its identifier. This endpoint returns the given message
+        Find a block by its identifier. This endpoint returns the given block
         as JSON.
       parameters:
         - in: path
-          name: messageId
+          name: blockId
           schema:
             type: string
           example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           required: true
-          description: Identifier of the message.
+          description: Identifier of the block.
       responses:
         '200':
           description: "Successful operation."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MessageResponse'
+                $ref: '#/components/schemas/BlockResponse'
               examples:
                 Empty Payload:
                   $ref: >-
-                    #/components/examples/get-message-by-id-empty-response-example
+                    #/components/examples/get-block-by-id-empty-response-example
                 Transaction Payload:
                   $ref: >-
-                    #/components/examples/get-message-by-id-transaction-response-example
+                    #/components/examples/get-block-by-id-transaction-response-example
                 Milestone Payload:
                   $ref: >-
-                    #/components/examples/get-message-by-id-milestone-response-example
+                    #/components/examples/get-block-by-id-milestone-response-example
                 Tagged Data Payload:
                   $ref: >-
-                    #/components/examples/get-message-by-id-tagged-data-response-example
+                    #/components/examples/get-block-by-id-tagged-data-response-example
             application/vnd.iota.serializer-v1:
               schema:
                 type: string
                 format: binary
-                description: message in raw binary format
+                description: block in raw binary format
                 example: >-
                   0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
         '400':
@@ -257,40 +257,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/messages/{messageId}/metadata':
+  '/api/v2/blocks/{blockId}/metadata':
     get:
       tags:
-        - messages
-      summary: Find the metadata of a given message.
+        - blocks
+      summary: Find the metadata of a given block.
       description: >-
-        Find the metadata of a given message.
+        Find the metadata of a given block.
       parameters:
         - in: path
-          name: messageId
+          name: blockId
           schema:
             type: string
           example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           required: true
-          description: Identifier of the message.
+          description: Identifier of the block.
       responses:
         '200':
           description: "Successful operation."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MessageMetadataResponse'
+                $ref: '#/components/schemas/BlockMetadataResponse'
               examples:
-                New Message:
-                  $ref: '#/components/examples/get-message-by-id-response-example-new'
+                New Block:
+                  $ref: '#/components/examples/get-block-by-id-response-example-new'
                 Solid:
                   $ref: >-
-                    #/components/examples/get-message-by-id-response-example-solid
+                    #/components/examples/get-block-by-id-response-example-solid
                 Included:
                   $ref: >-
-                    #/components/examples/get-message-by-id-response-example-included
+                    #/components/examples/get-block-by-id-response-example-included
                 Conflicting:
                   $ref: >-
-                    #/components/examples/get-message-by-id-response-example-conflicting
+                    #/components/examples/get-block-by-id-response-example-conflicting
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -321,34 +321,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/messages/{messageId}/children':
+  '/api/v2/blocks/{blockId}/children':
     get:
       tags:
-        - messages
-      summary: Returns the children of a message.
-      description: Returns the children of a message.
+        - blocks
+      summary: Returns the children of a block.
+      description: Returns the children of a block.
       parameters:
         - in: path
-          name: messageId
+          name: blockId
           schema:
             type: string
           example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           required: true
-          description: Identifier of the message.
+          description: Identifier of the block.
       responses:
         '200':
           description: "Successful operation."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MessageChildrenResponse'
+                $ref: '#/components/schemas/BlockChildrenResponse'
               examples:
                 Children were found:
                   $ref: >-
-                    #/components/examples/get-messages-by-id-response-example-children
+                    #/components/examples/get-blocks-by-id-response-example-children
                 No children were found:
                   $ref: >-
-                    #/components/examples/get-messages-by-id-response-example-nochildren
+                    #/components/examples/get-blocks-by-id-response-example-nochildren
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -613,12 +613,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  '/api/v2/transactions/{transactionId}/included-message':
+  '/api/v2/transactions/{transactionId}/included-block':
     get:
       tags:
         - UTXO
-      summary: Returns the included message of a transaction.
-      description: Returns the included message of a transaction.
+      summary: Returns the included block of a transaction.
+      description: Returns the included block of a transaction.
       parameters:
         - in: path
           name: transactionId
@@ -633,15 +633,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MessageResponse'
+                $ref: '#/components/schemas/BlockResponse'
               examples:
                 default:
-                  $ref: '#/components/examples/get-included-message-of-transaction-example-json'
+                  $ref: '#/components/examples/get-included-block-of-transaction-example-json'
             application/vnd.iota.serializer-v1:
               schema:
                 type: string
                 format: binary
-                description: message in raw binary format
+                description: block in raw binary format
                 example: >-
                   0204174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d65807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695de9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652530100000600000001c9b000b41dc00400010000af7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef00000e6c2998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a79010003a08601000000000000010000a18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b0069000000050000000b68656c6c6f20776f726c64550000005370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b57301000000ee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f40500492a353f96883c472e2686a640e77eda30be8fcc417aa9fc1c15eae854661e0253287be6ea68f649f19ca590de0a6c57fb88635ef0e013310e0be2b8360950350390000000000f0
         '400':
@@ -968,7 +968,7 @@ paths:
             type: string
           example: 12D3KooWMajsSUxSUFb3CRgmJvygYCGd27uMDdppVYNGud7xuKG5
           required: true
-          description: Identifier of the message.
+          description: Identifier of the block.
       responses:
         '200':
           description: "Successful operation."
@@ -1197,8 +1197,8 @@ components:
             milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
           pruningIndex: 0
         metrics:
-          messagesPerSecond: 17
-          referencedMessagesPerSecond: 16.8
+          blocksPerSecond: 17
+          referencedBlocksPerSecond: 16.8
           referencedRate: 98.82352941176471
         protocol:
           networkName: iota-testnet
@@ -1236,8 +1236,8 @@ components:
             milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
           pruningIndex: 0
         metrics:
-          messagesPerSecond: 17
-          referencedMessagesPerSecond: 16.8
+          blocksPerSecond: 17
+          referencedBlocksPerSecond: 16.8
           referencedRate: 98.82352941176471
         protocol:
           networkName: shimmer-testnet
@@ -1263,48 +1263,48 @@ components:
 
     get-tips-response-example:
       value:
-        tipMessageIds:
+        tipBlockIds:
           - "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           - "0x78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"
 
-    post-messages-response-example:
+    post-blocks-response-example:
       value:
-        messageId: "0xa4dd36465af63d495d35a05f592d42a51511c153e1bae8fad00453c8cbb48727"
+        blockId: "0xa4dd36465af63d495d35a05f592d42a51511c153e1bae8fad00453c8cbb48727"
 
-    get-message-by-id-response-example-new:
+    get-block-by-id-response-example-new:
       value:
-        messageId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentMessageIds:
+        blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
+        parentBlockIds:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: false
         shouldPromote: true
         shouldReattach: false
 
-    get-message-by-id-response-example-solid:
+    get-block-by-id-response-example-solid:
       value:
-        messageId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentMessageIds:
+        blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
+        parentBlockIds:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
         shouldPromote: false
         shouldReattach: false
 
-    get-message-by-id-response-example-included:
+    get-block-by-id-response-example-included:
       value:
-        messageId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentMessageIds:
+        blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
+        parentBlockIds:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
         referencedByMilestoneIndex: 15465
         ledgerInclusionState: included
 
-    get-message-by-id-response-example-conflicting:
+    get-block-by-id-response-example-conflicting:
       value:
-        messageId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentMessageIds:
+        blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
+        parentBlockIds:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
@@ -1312,10 +1312,10 @@ components:
         ledgerInclusionState: conflicting
         conflictReason: 1
 
-    post-tagged-data-message-request-example-full:
+    post-tagged-data-block-request-example-full:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
           - "0xa6db9d0b3ecb274d90c21e9dde04012b2d13ad8aa0b90e82e7d3b626be67119d"
@@ -1326,14 +1326,14 @@ components:
           data: "0x5370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b573"
         nonce: "2102864"
 
-    post-tagged-data-message-request-example-minimal:
+    post-tagged-data-block-request-example-minimal:
       value:
         payload:
           type: 5
           tag: "0x68656c6c6f20776f726c64"
           data: "0x5370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b573"
 
-    post-transaction-message-request-example-minimal:
+    post-transaction-block-request-example-minimal:
       value:
         payload:
           type: 6
@@ -1372,10 +1372,10 @@ components:
               reference: 0
         nonce: '1020884'
 
-    post-transaction-message-request-example-full:
+    post-transaction-block-request-example-full:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
           - "0xc107c5f3d6189954c9b1b8e2fa556db4bcf7ad2da717d328ecf6d9a841a5f37d"
@@ -1417,19 +1417,19 @@ components:
               reference: 0
         nonce: '1020884'
 
-    get-message-by-id-empty-response-example:
+    get-block-by-id-empty-response-example:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0xc0b728d4c292860b57747c7bfbd989ccc40be8c76229022644c05e1352bf1ea3"
           - "0xe8db39681478cf9826bd2f31d045f16f5e1f478c5abc3030419da7911df9e288"
         payload: null
         nonce: '1481'
 
-    get-message-by-id-transaction-response-example:
+    get-block-by-id-transaction-response-example:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
           - "0xc107c5f3d6189954c9b1b8e2fa556db4bcf7ad2da717d328ecf6d9a841a5f37d"
@@ -1471,10 +1471,10 @@ components:
               reference: 0
         nonce: '1020884'
 
-    get-message-by-id-milestone-response-example:
+    get-block-by-id-milestone-response-example:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
           - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
           - "0x2a331c562b48e261c11f073c7465551ffcc80c35ab6d09f4fd1cc81782e5fdc1"
@@ -1485,7 +1485,7 @@ components:
           type: 1
           index: 16241
           timestamp: 1617959712
-          parentMessageIds:
+          parentBlockIds:
             - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
             - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
             - "0x2a331c562b48e261c11f073c7465551ffcc80c35ab6d09f4fd1cc81782e5fdc1"
@@ -1504,10 +1504,10 @@ components:
             - "0x4bdfa2684bed01ce3a9a630b0688e868c290b8524c679daa79cb9d9f0f2aa5c57cf00a0fc694d1fed3696053ffa9bba6154ccb1564532cd49f807ba77de9a70c"
         nonce: '1229782938247321090'
 
-    get-message-by-id-tagged-data-response-example:
+    get-block-by-id-tagged-data-response-example:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
           - "0xa6db9d0b3ecb274d90c21e9dde04012b2d13ad8aa0b90e82e7d3b626be67119d"
@@ -1518,26 +1518,26 @@ components:
           data: "0x5370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b573"
         nonce: '2102864'
 
-    get-messages-by-id-response-example-children:
+    get-blocks-by-id-response-example-children:
       value:
-        messageId: "0xed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
+        blockId: "0xed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
         maxResults: 1000
         count: 2
-        childrenMessageIds:
+        childrenBlockIds:
           - "0x1c6943b0487c92fd057d4d22ad844cc37ee27fe6fbe88e5ff0d20b2233f75b9d"
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
 
-    get-messages-by-id-response-example-nochildren:
+    get-blocks-by-id-response-example-nochildren:
       value:
-        messageId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
+        blockId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         maxResults: 1000
         count: 0
-        childrenMessageIds: [ ]
+        childrenBlockIds: [ ]
 
     get-outputs-by-id-response-unspent-example:
       value:
         metadata:
-          messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+          blockId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
           transactionId: "0x1ee46e19f4219ee65afc10227d0ca22753f76ef32d1e922e5cbe3fbc9b5a5298"
           outputIndex: 1
           isSpent: false
@@ -1556,7 +1556,7 @@ components:
     get-outputs-by-id-response-spent-example:
       value:
         metadata:
-          messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+          blockId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
           transactionId: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a2"
           outputIndex: 1
           isSpent: true
@@ -1577,7 +1577,7 @@ components:
 
     get-output-metadata-by-id-response-unspent-example:
       value:
-        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+        blockId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
         transactionId: "0x1ee46e19f4219ee65afc10227d0ca22753f76ef32d1e922e5cbe3fbc9b5a5298"
         outputIndex: 1
         isSpent: false
@@ -1587,7 +1587,7 @@ components:
 
     get-output-metadata-by-id-response-spent-example:
       value:
-        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+        blockId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
         transactionId: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a2"
         outputIndex: 1
         isSpent: true
@@ -1622,10 +1622,10 @@ components:
         milestoneId: "0x733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d"
         amount: "133713371337"
 
-    get-included-message-of-transaction-example-json:
+    get-included-block-of-transaction-example-json:
       value:
         protocolVersion: 1
-        parentMessageIds:
+        parentBlockIds:
           - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
           - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -1666,7 +1666,7 @@ components:
         index: 15465
         timestamp: 1602227215
         previousMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
-        parentMessageIds:
+        parentBlockIds:
          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
          - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
          - "0xde9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652"
@@ -1711,14 +1711,14 @@ components:
               connectedNeighbors: 5
               syncedNeighbors: 7
             metrics:
-              newMessages: 3799
-              knownMessages: 554
-              receivedMessages: 4370
-              receivedMessageRequests: 0
+              newBlocks: 3799
+              knownBlocks: 554
+              receivedBlocks: 4370
+              receivedBlockRequests: 0
               receivedMilestoneRequests: 1
               receivedHeartbeats: 1
-              sentMessages: 6
-              sentMessageRequests: 4325
+              sentBlocks: 6
+              sentBlockRequests: 4325
               sentMilestoneRequests: 31
               sentHeartbeats: 9
               droppedPackets: 0
@@ -1736,14 +1736,14 @@ components:
               connectedNeighbors: 5
               syncedNeighbors: 6
             metrics:
-              newMessages: 510
-              knownMessages: 79
-              receivedMessages: 589
-              receivedMessageRequests: 0
+              newBlocks: 510
+              knownBlocks: 79
+              receivedBlocks: 589
+              receivedBlockRequests: 0
               receivedMilestoneRequests: 1
               receivedHeartbeats: 1
-              sentMessages: 42
-              sentMessageRequests: 576
+              sentBlocks: 42
+              sentBlockRequests: 576
               sentMilestoneRequests: 1
               sentHeartbeats: 9
               droppedPackets: 0
@@ -1764,14 +1764,14 @@ components:
             connectedNeighbors: 5
             syncedNeighbors: 7
           metrics:
-            newMessages: 3799
-            knownMessages: 554
-            receivedMessages: 4370
-            receivedMessageRequests: 0
+            newBlocks: 3799
+            knownBlocks: 554
+            receivedBlocks: 4370
+            receivedBlockRequests: 0
             receivedMilestoneRequests: 1
             receivedHeartbeats: 1
-            sentMessages: 6
-            sentMessageRequests: 4325
+            sentBlocks: 6
+            sentBlockRequests: 4325
             sentMilestoneRequests: 31
             sentHeartbeats: 9
             droppedPackets: 0
@@ -1798,14 +1798,14 @@ components:
             connectedNeighbors: 5
             syncedNeighbors: 7
           metrics:
-            newMessages: 3799
-            knownMessages: 554
-            receivedMessages: 4370
-            receivedMessageRequests: 0
+            newBlocks: 3799
+            knownBlocks: 554
+            receivedBlocks: 4370
+            receivedBlockRequests: 0
             receivedMilestoneRequests: 1
             receivedHeartbeats: 1
-            sentMessages: 6
-            sentMessageRequests: 4325
+            sentBlocks: 6
+            sentBlockRequests: 4325
             sentMilestoneRequests: 31
             sentHeartbeats: 9
             droppedPackets: 0
@@ -1814,7 +1814,7 @@ components:
       value:
         index: 1560
         timestamp: 1602227215
-        parentMessageIds:
+        parentBlockIds:
           - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
           - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -1854,19 +1854,19 @@ components:
 
   schemas:
 
-    Message:
-      description: A message is the object nodes gossip around in the network. It always references two other messages that are known as parents. It is stored as a vertex on the tangle data structure that the nodes maintain. A message can have a maximum size of 32Kb.
+    Block:
+      description: A block is the object nodes gossip around in the network. It always references two other blocks that are known as parents. It is stored as a vertex on the tangle data structure that the nodes maintain. A block can have a maximum size of 32Kb.
       properties:
         protocolVersion:
           type: number
-          description: Protocol version identifier. It also tells which protocol rules apply to the message.
-        parentMessageIds:
+          description: Protocol version identifier. It also tells which protocol rules apply to the block.
+        parentBlockIds:
           type: array
-          description: The identifiers of the messages this message references. Hex-encoded data with 0x prefix.
+          description: The identifiers of the blocks this block references. Hex-encoded data with 0x prefix.
           items:
             type: string
         payload:
-          description: The inner payload of the message. Can be nil.
+          description: The inner payload of the block. Can be nil.
           oneOf:
             - $ref: '#/components/schemas/TransactionPayload'
             - $ref: '#/components/schemas/MilestonePayload'
@@ -1874,14 +1874,14 @@ components:
             - $ref: '#/components/schemas/ReceiptPayload'
         nonce:
           type: string
-          description: The nonce which lets this message fulfill the Proof-of-Work requirement. Plain string encoded number.
+          description: The nonce which lets this block fulfill the Proof-of-Work requirement. Plain string encoded number.
       required:
         - protocolVersion
-        - parentMessageIds
+        - parentBlockIds
         - nonce
 
     TransactionPayload:
-      description: The Transaction Payload to be embedded into a message.
+      description: The Transaction Payload to be embedded into a block.
       properties:
         type:
           type: integer
@@ -1911,7 +1911,7 @@ components:
           description: Set to value 1 to denote a Transaction Essence.
         networkId:
           type: string
-          description: Network identifier. Plain string encoded number. This field signals for which network the message is meant for. It is computed out of the first 8 bytes of the `BLAKE2b-256` hash of the concatenation of the network name and protocol version string.
+          description: Network identifier. Plain string encoded number. This field signals for which network the block is meant for. It is computed out of the first 8 bytes of the `BLAKE2b-256` hash of the concatenation of the network name and protocol version string.
         inputsCommitment:
           type: string
           description: BLAKE2b-256 hash of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
@@ -2468,7 +2468,7 @@ components:
         - reference
 
     MilestonePayload:
-      description: The Milestone Payload to be embedded into a message.
+      description: The Milestone Payload to be embedded into a block.
       properties:
         type:
           type: integer
@@ -2482,17 +2482,17 @@ components:
         previousMilestoneId:
           type: string
           description: The Milestone ID of the milestone with Index Number - 1.
-        parentMessageIds:
-          description: The identifiers of the messages this milestone references. Hex-encoded values with 0x prefix.
+        parentBlockIds:
+          description: The identifiers of the blocks this milestone references. Hex-encoded values with 0x prefix.
           type: array
           items:
             type: string
         confirmedMerkleRoot:
           type: string
-          description: The merkle root of all directly/indirectly referenced messages (their IDs) which are newly confirmed by this milestone. Hex-encoded with 0x prefix.
+          description: The merkle root of all directly/indirectly referenced blocks (their IDs) which are newly confirmed by this milestone. Hex-encoded with 0x prefix.
         appliedMerkleRoot:
           type: string
-          description: The merkle root of all messages (their IDs) carrying ledger state mutating transactions. Hex-encoded with 0x prefix.
+          description: The merkle root of all blocks (their IDs) carrying ledger state mutating transactions. Hex-encoded with 0x prefix.
         options:
           type: array
           items:
@@ -2513,20 +2513,20 @@ components:
         - index
         - timestamp
         - previousMilestoneId
-        - parentMessageIds
+        - parentBlockIds
         - confirmedMerkleRoot
         - appliedMerkleRoot
         - signatures
 
     TaggedDataPayload:
-      description: The Tagged Data Payload to be embedded into a message.
+      description: The Tagged Data Payload to be embedded into a block.
       properties:
         type:
           type: integer
           description: Set to value 5 to denote a Tagged Data Payload.
         tag:
           type: string
-          description: The indexation key to allow external tools to find/look up this message. It has a size between 1 and 64 bytes and must be encoded as a hex-string with 0x prefix.
+          description: The indexation key to allow external tools to find/look up this block. It has a size between 1 and 64 bytes and must be encoded as a hex-string with 0x prefix.
         data:
           type: string
           description: The optional data to attach. This may have a length of 0. Hex-encoded with 0x prefix.
@@ -2641,30 +2641,30 @@ components:
 
     Metrics:
       properties:
-        newMessages:
+        newBlocks:
           type: integer
-          description: The number of received messages that were new for the node.
-        knownMessages:
+          description: The number of received blocks that were new for the node.
+        knownBlocks:
           type: integer
-          description: The number of received messages that already were known to the node.
-        receivedMessages:
+          description: The number of received blocks that already were known to the node.
+        receivedBlocks:
           type: integer
-          description: The number of received messages from the peer.
-        receivedMessageRequests:
+          description: The number of received blocks from the peer.
+        receivedBlockRequests:
           type: integer
-          description: The number of received message requests from the peer.
+          description: The number of received block requests from the peer.
         receivedMilestoneRequests:
           type: integer
           description: The number of received milestone requests from the peer.
         receivedHeartbeats:
           type: integer
           description: The number of received heartbeats from the peer.
-        sentMessages:
+        sentBlocks:
           type: integer
-          description: The number of sent messages to the peer.
-        sentMessageRequests:
+          description: The number of sent blocks to the peer.
+        sentBlockRequests:
           type: integer
-          description: The number of sent message requests to the peer.
+          description: The number of sent block requests to the peer.
         sentMilestoneRequests:
           type: integer
           description: The number of sent milestone requests to the peer.
@@ -2675,14 +2675,14 @@ components:
           type: integer
           description: The number of dropped packets.
       required:
-        - newMessages
-        - knownMessages
-        - receivedMessages
-        - receivedMessageRequests
+        - newBlocks
+        - knownBlocks
+        - receivedBlocks
+        - receivedBlockRequests
         - receivedMilestoneRequests
         - receivedHeartbeats
-        - sentMessages
-        - sentMessageRequests
+        - sentBlocks
+        - sentBlockRequests
         - sentMilestoneRequests
         - sentHeartbeats
         - droppedPackets
@@ -2758,12 +2758,12 @@ components:
             code:
               type: string
               description: The application error code.
-            message:
+            block:
               type: string
               description: The error reason.
           required:
             - code
-            - message
+            - block
       required:
         - error
 
@@ -2774,7 +2774,7 @@ components:
       example:
         error:
           code: 403
-          message: not available for public use
+          block: not available for public use
 
     ServiceUnavailableResponse:
       description: Indicates that the service is unavailable.
@@ -2783,7 +2783,7 @@ components:
       example:
         error:
           code: 503
-          message: service unavailable
+          block: service unavailable
 
     BadRequestResponse:
       description: Indicates that the request was bad.
@@ -2792,7 +2792,7 @@ components:
       example:
         error:
           code: 400
-          message: invalid data provided
+          block: invalid data provided
 
     NotFoundResponse:
       description: Indicates that the data was not found.
@@ -2801,7 +2801,7 @@ components:
       example:
         error:
           code: 404
-          message: could not find data
+          block: could not find data
 
     InternalErrorResponse:
       description: Indicates that the server encountered an unexpected condition, which prevented it from fulfilling the request by the client.
@@ -2810,7 +2810,7 @@ components:
       example:
         error:
           code: 500
-          message: internal server error
+          block: internal server error
 
     InfoResponse:
       description: Returns general information about the node.
@@ -2864,21 +2864,21 @@ components:
         metrics:
           description: Node metrics.
           properties:
-            messagesPerSecond:
-              description: The current rate of new messages per second.
+            blocksPerSecond:
+              description: The current rate of new blocks per second.
               type: number
               format: float
-            referencedMessagesPerSecond:
-              description: The current rate of referenced messages per second.
+            referencedBlocksPerSecond:
+              description: The current rate of referenced blocks per second.
               type: number
               format: float
             referencedRate:
-              description: The ratio of referenced messages in relation to new messages of the last confirmed milestone.
+              description: The ratio of referenced blocks in relation to new blocks of the last confirmed milestone.
               type: number
               format: float
           required:
-            - messagesPerSecond
-            - referencedMessagesPerSecond
+            - blocksPerSecond
+            - referencedBlocksPerSecond
             - referencedRate
         protocol:
           description: Protocol parameters.
@@ -2896,7 +2896,7 @@ components:
               type: integer
               description: Protocol version used by the network.
             minPoWScore:
-              description: The Proof-of-Work difficulty for a message to be sent over the network to mitigate spam.
+              description: The Proof-of-Work difficulty for a block to be sent over the network to mitigate spam.
               type: number
               format: float
             rentStructure:
@@ -2970,25 +2970,25 @@ components:
         - plugins
 
     TipsResponse:
-      description: Returns tips that are ideal for attaching a message.
+      description: Returns tips that are ideal for attaching a block.
       properties:
-        tipMessageIds:
+        tipBlockIds:
           type: array
           items:
             type: string
-          description: The message identifiers that can be used to a attach a message to. Hex-encoded with 0x prefix.
+          description: The block identifiers that can be used to a attach a block to. Hex-encoded with 0x prefix.
       required:
-        - tipMessageIds
+        - tipBlockIds
 
-    SubmitMessageRequest:
-      description: Submits a message to the node.
+    SubmitBlockRequest:
+      description: Submits a block to the node.
       properties:
         protocolVersion:
           type: integer
-          description: Protocol version number of the message.It also tells which protocol rules apply to the message.
-        parentMessageIds:
+          description: Protocol version number of the block.It also tells which protocol rules apply to the block.
+        parentBlockIds:
           type: array
-          description: The identifiers of the messages this message references. Hex-encoded with 0x prefix.
+          description: The identifiers of the blocks this block references. Hex-encoded with 0x prefix.
           items:
             type: string
         payload:
@@ -3000,45 +3000,45 @@ components:
             - $ref: '#/components/schemas/ReceiptPayload'
         nonce:
           type: string
-          description: The nonce which lets this message fulfill the Proof-of-Work requirement. Hex-encoded with 0x prefix.
+          description: The nonce which lets this block fulfill the Proof-of-Work requirement. Hex-encoded with 0x prefix.
 
-    SubmitMessageResponse:
-      description: Returns the message identifier of the submitted message.
+    SubmitBlockResponse:
+      description: Returns the block identifier of the submitted block.
       properties:
-        messageId:
+        blockId:
           type: string
-          description: The message identifier of the submitted message. Hex-encoded with 0x prefix.
+          description: The block identifier of the submitted block. Hex-encoded with 0x prefix.
       required:
-        - messageId
+        - blockId
 
-    MessageMetadataResponse:
-      description: Returns the metadata of a given message.
+    BlockMetadataResponse:
+      description: Returns the metadata of a given block.
       properties:
-        messageId:
+        blockId:
           type: string
-          description: The identifier of the message. Hex-encoded with 0x prefix.
-        parentMessageIds:
+          description: The identifier of the block. Hex-encoded with 0x prefix.
+        parentBlockIds:
           type: array
-          description: The identifiers of the messages this message references. Hex-encoded with 0x prefix.
+          description: The identifiers of the blocks this block references. Hex-encoded with 0x prefix.
           items:
             type: string
         isSolid:
           type: boolean
-          description: Tells if the message could get solidified by the node or not.
+          description: Tells if the block could get solidified by the node or not.
         referencedByMilestoneIndex:
           type: integer
           nullable: true
-          description: Tells which milestone references this message. If `null` the message was not referenced by a milestone yet.
+          description: Tells which milestone references this block. If `null` the block was not referenced by a milestone yet.
         milestoneIndex:
           type: integer
-          description: If set, this message can be considered as a valid milestone message. This field therefore describes the milestone index of the involved milestone. A message can be considered as a valid milestone message if the milestone payload is valid and if the referenced parents in the milestone payload do match the referenced parents in the message itself. Note it's possible to have different milestone messages that all represent the same milestone.
+          description: If set, this block can be considered as a valid milestone block. This field therefore describes the milestone index of the involved milestone. A block can be considered as a valid milestone block if the milestone payload is valid and if the referenced parents in the milestone payload do match the referenced parents in the block itself. Note it's possible to have different milestone blocks that all represent the same milestone.
         ledgerInclusionState:
           type: string
           enum:
             - included
             - conflicting
             - noTransaction
-          description: If `included`, the message contains a transaction that has been included in the ledger. If `conflicitng`, the message contains a transaction that has not been included in the ledger because it conflicts with another transaction. If the message does not contain a transaction, `ledgerInclusionState` is set to `noTransaction`.
+          description: If `included`, the block contains a transaction that has been included in the ledger. If `conflicitng`, the block contains a transaction that has not been included in the ledger because it conflicts with another transaction. If the block does not contain a transaction, `ledgerInclusionState` is set to `noTransaction`.
         conflictReason:
           type: integer
           enum: [1,2,3,4,5,6,7,8,9,10,11,12,255]
@@ -3060,43 +3060,43 @@ components:
 
         shouldPromote:
           type: boolean
-          description: Tells if the message should be promoted to get more likely picked up by the Coordinator.
+          description: Tells if the block should be promoted to get more likely picked up by the Coordinator.
         shouldReattach:
           type: boolean
-          description: Tells if the message should be reattached.
+          description: Tells if the block should be reattached.
       required:
-        - messageId
-        - parentMessageIds
+        - blockId
+        - parentBlockIds
         - isSolid
 
-    MessageResponse:
-      description: Returns a given message.
+    BlockResponse:
+      description: Returns a given block.
       properties:
         allOf:
-          $ref: '#/components/schemas/Message'
+          $ref: '#/components/schemas/Block'
 
-    MessageChildrenResponse:
-      description: Returns the children of a given message.
+    BlockChildrenResponse:
+      description: Returns the children of a given block.
       properties:
-        messageId:
+        blockId:
           type: string
-          description: The message identifier of the given message that was used to look up its children. Hex-encoded with 0x prefix.
+          description: The block identifier of the given block that was used to look up its children. Hex-encoded with 0x prefix.
         maxResults:
           type: integer
           description: The number of results it can return at most.
         count:
           type: integer
           description: The actual number of found results.
-        childrenMessageIds:
+        childrenBlockIds:
           type: array
           items:
             type: string
-          description: The message identifiers of the found children. Hex-encoded with 0x prefix.
+          description: The block identifiers of the found children. Hex-encoded with 0x prefix.
       required:
-        - messageId
+        - blockId
         - maxResults
         - count
-        - childrenMessageIds
+        - childrenBlockIds
 
     OutputResponse:
       description: Returns an output and its metadata.
@@ -3119,9 +3119,9 @@ components:
     OutputMetadataResponse:
       description: Returns metadata about an output.
       properties:
-        messageId:
+        blockId:
           type: string
-          description: The message identifier that references the output. Hex-encoded with 0x prefix.
+          description: The block identifier that references the output. Hex-encoded with 0x prefix.
         transactionId:
           type: string
           description: The identifier of the transaction. Hex-encoded with 0x prefix.
@@ -3153,7 +3153,7 @@ components:
           type: integer
           description: The current ledger index for which the request was made.
       required:
-        - messageId
+        - blockId
         - transactionId
         - outputIndex
         - isSpent
@@ -3187,15 +3187,15 @@ components:
         index:
           type: integer
           description: The index number of the milestone.
-        messageId:
+        blockId:
           type: string
-          description: The identifier of a message which describes this milestone. Note that different messages could describe the same milestone. Hex-encoded with 0x prefix.
+          description: The identifier of a block which describes this milestone. Note that different blocks could describe the same milestone. Hex-encoded with 0x prefix.
         timestamp:
           type: integer
           description: The timestamp of when the  milestone was issued.
       required:
         - index
-        - messageId
+        - blockId
         - timestamp
 
     UTXOChangesResponse:
@@ -3258,9 +3258,9 @@ components:
         timestamp:
           type: integer
           description: The timestamp of the milestone.
-        parentMessageIds:
+        parentBlockIds:
           type: array
-          description: The hex encoded message IDs of the parents the milestone references.
+          description: The hex encoded block IDs of the parents the milestone references.
           items:
             type: string
         previousMilestoneId:
@@ -3269,7 +3269,7 @@ components:
       required:
         - index
         - timestamp
-        - parentMessageIds
+        - parentBlockIds
         - previousMilestoneId
 
     ComputeWhiteFlagResponse:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -321,53 +321,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/blocks/{blockId}/children':
-    get:
-      tags:
-        - blocks
-      summary: Returns the children of a block.
-      description: Returns the children of a block.
-      parameters:
-        - in: path
-          name: blockId
-          schema:
-            type: string
-          example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-          required: true
-          description: Identifier of the block.
-      responses:
-        '200':
-          description: "Successful operation."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlockChildrenResponse'
-              examples:
-                Children were found:
-                  $ref: >-
-                    #/components/examples/get-blocks-by-id-response-example-children
-                No children were found:
-                  $ref: >-
-                    #/components/examples/get-blocks-by-id-response-example-nochildren
-        '400':
-          description: "Unsuccessful operation: indicates that the provided data is invalid."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '403':
-          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-        '500':
-          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalErrorResponse'
-
+  
   '/api/v2/outputs/{outputId}':
     get:
       tags:
@@ -1518,22 +1472,6 @@ components:
           data: "0x5370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b573"
         nonce: '2102864'
 
-    get-blocks-by-id-response-example-children:
-      value:
-        blockId: "0xed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
-        maxResults: 1000
-        count: 2
-        children:
-          - "0x1c6943b0487c92fd057d4d22ad844cc37ee27fe6fbe88e5ff0d20b2233f75b9d"
-          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
-
-    get-blocks-by-id-response-example-nochildren:
-      value:
-        blockId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
-        maxResults: 1000
-        count: 0
-        children: [ ]
-
     get-outputs-by-id-response-unspent-example:
       value:
         metadata:
@@ -2575,7 +2513,7 @@ components:
           description: Set to value 2 to denote a TreasuryOutput.
         amount:
           type: string
-          description: Amountt of IOTA tokens in the treasury. Plain string encoded number.
+          description: Amount of IOTA tokens in the treasury. Plain string encoded number.
       required:
         - type
         - amount
@@ -3099,29 +3037,6 @@ components:
       properties:
         allOf:
           $ref: '#/components/schemas/Block'
-
-    BlockChildrenResponse:
-      description: Returns the children of a given block.
-      properties:
-        blockId:
-          type: string
-          description: The block identifier of the given block that was used to look up its children. Hex-encoded with 0x prefix.
-        maxResults:
-          type: integer
-          description: The number of results it can return at most.
-        count:
-          type: integer
-          description: The actual number of found results.
-        children:
-          type: array
-          items:
-            type: string
-          description: The block identifiers of the found children. Hex-encoded with 0x prefix.
-      required:
-        - blockId
-        - maxResults
-        - count
-        - children
 
     OutputResponse:
       description: Returns an output and its metadata.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2534,7 +2534,7 @@ components:
           description: Set to value 5 to denote a Tagged Data Payload.
         tag:
           type: string
-          description: The tag to allow external tools to find/look up this block. It has a size between 1 and 64 bytes and must be encoded as a hex-string with 0x prefix. Network nodes do not index blocks with Tagged Data Payload by the tag field by default.
+          description: The tag to allow external tools to find/look up this block. It has a size between 0 and 64 bytes and must be encoded as a hex-string with 0x prefix. Network nodes do not index blocks with Tagged Data Payload by the tag field by default.
         data:
           type: string
           description: The optional data to attach. This may have a length of 0. Hex-encoded with 0x prefix.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1311,6 +1311,7 @@ components:
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
         referencedByMilestoneIndex: 15465
+        whiteFlagIndex: 25
         ledgerInclusionState: included
 
     get-block-by-id-response-example-conflicting:
@@ -1321,6 +1322,7 @@ components:
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
         referencedByMilestoneIndex: 15465
+        whiteFlagIndex: 25
         ledgerInclusionState: conflicting
         conflictReason: 1
 
@@ -3099,7 +3101,9 @@ components:
               * `11` - denotes that an output contains a Sender with an ident (address) which is not unlocked.
               * `12` - denotes that the chain state transition is invalid.
               * `255` - denotes that the semantic validation failed.
-
+        whiteFlagIndex:
+          type: integer
+          description: If set, defines the order of the block in the white flag traversal during milestone solidification. Only referenced blocks have this information.
         shouldPromote:
           type: boolean
           description: Tells if the block should be promoted to get more likely picked up by the Coordinator.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1328,7 +1328,7 @@ components:
 
     post-tagged-data-block-request-example-full:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
@@ -1388,7 +1388,7 @@ components:
 
     post-transaction-block-request-example-full:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
@@ -1433,7 +1433,7 @@ components:
 
     get-block-by-id-empty-response-example:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0xc0b728d4c292860b57747c7bfbd989ccc40be8c76229022644c05e1352bf1ea3"
           - "0xe8db39681478cf9826bd2f31d045f16f5e1f478c5abc3030419da7911df9e288"
@@ -1442,7 +1442,7 @@ components:
 
     get-block-by-id-transaction-response-example:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
@@ -1487,7 +1487,7 @@ components:
 
     get-block-by-id-milestone-response-example:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
           - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
@@ -1525,7 +1525,7 @@ components:
 
     get-block-by-id-tagged-data-response-example:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
@@ -1627,7 +1627,7 @@ components:
 
     get-included-block-of-transaction-example-json:
       value:
-        protocolVersion: 1
+        protocolVersion: 2
         parents:
           - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2530,7 +2530,7 @@ components:
           type: integer
           description: The milestone index at which this output was spent.
           nullable: true
-        milestoneTimesttampSpent:
+        milestoneTimestampSpent:
           type: integer
           description: The milestone timestamp this output was spent.
           nullable: true

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -321,7 +321,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  
+
   '/api/v2/outputs/{outputId}':
     get:
       tags:
@@ -1154,6 +1154,9 @@ components:
           blocksPerSecond: 17
           referencedBlocksPerSecond: 16.8
           referencedRate: 98.82352941176471
+        supportedProtocolVersions:
+          - 2
+          - 3
         protocol:
           networkName: iota-testnet
           bech32HRP: atoi
@@ -1164,6 +1167,19 @@ components:
             vByteCost: 500
             vByteFactorData: 1
             vByteFactorKey: 10
+        pendingProtocolParameters:
+          - type: 1
+            targetMilestoneIndex: 480
+            protocolVersion: 2
+            params: "0x03040560405060703940304956896"
+          - type: 1
+            targetMilestoneIndex: 485
+            protocolVersion: 2
+            params: "0x03040503045950393045930239392"
+          - type: 1
+            targetMilestoneIndex: 490
+            protocolVersion: 2
+            params: "0x02010290394032948950303939482"
         baseToken:
           name: "IOTA"
           tickerSymbol: "MIOTA"
@@ -1193,6 +1209,9 @@ components:
           blocksPerSecond: 17
           referencedBlocksPerSecond: 16.8
           referencedRate: 98.82352941176471
+        supportedProtocolVersions:
+          - 2
+          - 3
         protocol:
           networkName: shimmer-testnet
           bech32HRP: rms
@@ -1203,6 +1222,19 @@ components:
             vByteCost: 500
             vByteFactorData: 1
             vByteFactorKey: 10
+        pendingProtocolParameters:
+          - type: 1
+            targetMilestoneIndex: 480
+            protocolVersion: 2
+            params: "0x03040560405060703940304956896"
+          - type: 1
+            targetMilestoneIndex: 485
+            protocolVersion: 2
+            params: "0x03040503045950393045930239392"
+          - type: 1
+            targetMilestoneIndex: 490
+            protocolVersion: 2
+            params: "0x02010290394032948950303939482"
         baseToken:
           name: "Shimmer"
           tickerSymbol: "SMR"
@@ -2842,6 +2874,11 @@ components:
             - blocksPerSecond
             - referencedBlocksPerSecond
             - referencedRate
+        supportedProtocolVersions:
+          type: array
+          description: The supported protocol versions.
+          items:
+            type: integer
         protocol:
           description: Protocol parameters.
           properties:
@@ -2884,6 +2921,11 @@ components:
             - protocolVersion
             - minPoWScore
             - rentStructure
+        pendingProtocolParameters:
+          description: Pending protocol parameters.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProtocolParamsMilestoneOpt'
         baseToken:
           description: Gives info about the base token the network uses.
           properties:
@@ -2926,7 +2968,9 @@ components:
         - version
         - status
         - metrics
+        - supportedProtocolVersions
         - protocol
+        - pendingProtocolParameters
         - baseToken
         - features
         - plugins

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -127,7 +127,7 @@ paths:
         build the block. On success, the block will be stored in the Tangle.
         This endpoint will return the identifier of the built block. *The
         node will try to auto-fill the following fields in case they are
-        missing: `protocolVersion`, `parentBlockIds`, `nonce`.
+        missing: `protocolVersion`, `parents`, `nonce`.
         If `payload` is missing, the block will be built without a payload.
       requestBody:
         content:
@@ -1274,7 +1274,7 @@ components:
     get-block-by-id-response-example-new:
       value:
         blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentBlockIds:
+        parents:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: false
@@ -1284,7 +1284,7 @@ components:
     get-block-by-id-response-example-solid:
       value:
         blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentBlockIds:
+        parents:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
@@ -1294,7 +1294,7 @@ components:
     get-block-by-id-response-example-included:
       value:
         blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentBlockIds:
+        parents:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
@@ -1304,7 +1304,7 @@ components:
     get-block-by-id-response-example-conflicting:
       value:
         blockId: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-        parentBlockIds:
+        parents:
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
           - "0xd97e89e49ed263b763afeda192515fe154ec826ceb92ef08926cd68ec02c9510"
         isSolid: true
@@ -1315,7 +1315,7 @@ components:
     post-tagged-data-block-request-example-full:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
           - "0xa6db9d0b3ecb274d90c21e9dde04012b2d13ad8aa0b90e82e7d3b626be67119d"
@@ -1375,7 +1375,7 @@ components:
     post-transaction-block-request-example-full:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
           - "0xc107c5f3d6189954c9b1b8e2fa556db4bcf7ad2da717d328ecf6d9a841a5f37d"
@@ -1420,7 +1420,7 @@ components:
     get-block-by-id-empty-response-example:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0xc0b728d4c292860b57747c7bfbd989ccc40be8c76229022644c05e1352bf1ea3"
           - "0xe8db39681478cf9826bd2f31d045f16f5e1f478c5abc3030419da7911df9e288"
         payload: null
@@ -1429,7 +1429,7 @@ components:
     get-block-by-id-transaction-response-example:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x6c5bc96948813faaf6d5a5f0c6bc453bf2e5343664884aea2873041bdc47c4ca"
           - "0x97e2c4fce0f6e1023c19ed634e37a44744e21a743a79e8f1fc16d31dc8f47481"
           - "0xc107c5f3d6189954c9b1b8e2fa556db4bcf7ad2da717d328ecf6d9a841a5f37d"
@@ -1474,7 +1474,7 @@ components:
     get-block-by-id-milestone-response-example:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
           - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
           - "0x2a331c562b48e261c11f073c7465551ffcc80c35ab6d09f4fd1cc81782e5fdc1"
@@ -1485,7 +1485,7 @@ components:
           type: 1
           index: 16241
           timestamp: 1617959712
-          parentBlockIds:
+          parents:
             - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
             - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
             - "0x2a331c562b48e261c11f073c7465551ffcc80c35ab6d09f4fd1cc81782e5fdc1"
@@ -1507,7 +1507,7 @@ components:
     get-block-by-id-tagged-data-response-example:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x222e88a63e5aca8ef48d3b8749e2fab51d1bc7c34c5604a2933ca2f180b342c9"
           - "0xa22137ebe61435c6d0f3e16ad148376778d7bfb36e27329f02c221ec109525a6"
           - "0xa6db9d0b3ecb274d90c21e9dde04012b2d13ad8aa0b90e82e7d3b626be67119d"
@@ -1523,7 +1523,7 @@ components:
         blockId: "0xed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
         maxResults: 1000
         count: 2
-        childrenBlockIds:
+        children:
           - "0x1c6943b0487c92fd057d4d22ad844cc37ee27fe6fbe88e5ff0d20b2233f75b9d"
           - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
 
@@ -1532,7 +1532,7 @@ components:
         blockId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         maxResults: 1000
         count: 0
-        childrenBlockIds: [ ]
+        children: [ ]
 
     get-outputs-by-id-response-unspent-example:
       value:
@@ -1625,7 +1625,7 @@ components:
     get-included-block-of-transaction-example-json:
       value:
         protocolVersion: 1
-        parentBlockIds:
+        parents:
           - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
           - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -1666,11 +1666,11 @@ components:
         index: 15465
         timestamp: 1602227215
         previousMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
-        parentBlockIds:
+        parents:
          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
          - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
          - "0xde9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652"
-        confirmedMerkleRoot: "0xa18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b"
+        inclusionMerkleRoot: "0xa18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b"
         appliedMerkleRoot: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
         options:
          - type: 1
@@ -1814,7 +1814,7 @@ components:
       value:
         index: 1560
         timestamp: 1602227215
-        parentBlockIds:
+        parents:
           - "0x174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d6"
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
           - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -1823,7 +1823,7 @@ components:
 
     compute-whiteflag-response-example:
       value:
-        confirmedMerkleRoot: "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649"
+        inclusionMerkleRoot: "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649"
         appliedMerkleRoot: "0xbbffde11ef804fdbc7c8f62432937b7a00806c136eca21c54038d5a6bdd16251"
 
     database-prune-request-example:
@@ -1860,7 +1860,7 @@ components:
         protocolVersion:
           type: number
           description: Protocol version identifier. It also tells which protocol rules apply to the block.
-        parentBlockIds:
+        parents:
           type: array
           description: The identifiers of the blocks this block references. Hex-encoded data with 0x prefix.
           items:
@@ -1877,7 +1877,7 @@ components:
           description: The nonce which lets this block fulfill the Proof-of-Work requirement. Plain string encoded number.
       required:
         - protocolVersion
-        - parentBlockIds
+        - parents
         - nonce
 
     TransactionPayload:
@@ -2482,12 +2482,12 @@ components:
         previousMilestoneId:
           type: string
           description: The Milestone ID of the milestone with Index Number - 1.
-        parentBlockIds:
+        parents:
           description: The identifiers of the blocks this milestone references. Hex-encoded values with 0x prefix.
           type: array
           items:
             type: string
-        confirmedMerkleRoot:
+        inclusionMerkleRoot:
           type: string
           description: The merkle root of all directly/indirectly referenced blocks (their IDs) which are newly confirmed by this milestone. Hex-encoded with 0x prefix.
         appliedMerkleRoot:
@@ -2513,8 +2513,8 @@ components:
         - index
         - timestamp
         - previousMilestoneId
-        - parentBlockIds
-        - confirmedMerkleRoot
+        - parents
+        - inclusionMerkleRoot
         - appliedMerkleRoot
         - signatures
 
@@ -2606,7 +2606,6 @@ components:
         - multiAddresses
         - relation
         - connected
-        - gossip
 
     Gossip:
       description: Information about the gossip stream with the peer.
@@ -2986,7 +2985,7 @@ components:
         protocolVersion:
           type: integer
           description: Protocol version number of the block.It also tells which protocol rules apply to the block.
-        parentBlockIds:
+        parents:
           type: array
           description: The identifiers of the blocks this block references. Hex-encoded with 0x prefix.
           items:
@@ -3017,7 +3016,7 @@ components:
         blockId:
           type: string
           description: The identifier of the block. Hex-encoded with 0x prefix.
-        parentBlockIds:
+        parents:
           type: array
           description: The identifiers of the blocks this block references. Hex-encoded with 0x prefix.
           items:
@@ -3066,7 +3065,7 @@ components:
           description: Tells if the block should be reattached.
       required:
         - blockId
-        - parentBlockIds
+        - parents
         - isSolid
 
     BlockResponse:
@@ -3087,7 +3086,7 @@ components:
         count:
           type: integer
           description: The actual number of found results.
-        childrenBlockIds:
+        children:
           type: array
           items:
             type: string
@@ -3096,7 +3095,7 @@ components:
         - blockId
         - maxResults
         - count
-        - childrenBlockIds
+        - children
 
     OutputResponse:
       description: Returns an output and its metadata.
@@ -3258,7 +3257,7 @@ components:
         timestamp:
           type: integer
           description: The timestamp of the milestone.
-        parentBlockIds:
+        parents:
           type: array
           description: The hex encoded block IDs of the parents the milestone references.
           items:
@@ -3269,20 +3268,20 @@ components:
       required:
         - index
         - timestamp
-        - parentBlockIds
+        - parents
         - previousMilestoneId
 
     ComputeWhiteFlagResponse:
-      description: Returns the computed ConfirmedMerkleRoot and AppliedMerkleRoot
+      description: Returns the computed InclusionMerkleRoot and AppliedMerkleRoot
       properties:
-        confirmedMerkleRoot:
+        inclusionMerkleRoot:
           type: string
-          description: The hex encoded confirmed merkle tree root as a result of the white flag computation.
+          description: The hex encoded inclusion merkle tree root as a result of the white flag computation.
         appliedMerkleRoot:
           type: string
           description: The hex encoded applied merkle tree root as a result of the white flag computation.
       required:
-        - confirmedMerkleRoot
+        - inclusionMerkleRoot
         - appliedMerkleRoot
 
     PruneDatabaseRequest:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -555,7 +555,7 @@ paths:
         - UTXO
       summary: Returns information about the treasury.
       description: >-
-        Returns information about the treasury.
+        Returns information about the treasury. The treasury hold the unmigrated tokens from the Legacy Mainnet.
       responses:
         '200':
           description: "Successful operation."

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1215,7 +1215,6 @@ components:
           tickerSymbol: "MIOTA"
           unit: "IOTA"
           decimals: 0
-          subunit: null
           useMetricPrefix: true
         features:
           - PoW
@@ -2914,27 +2913,10 @@ components:
                 vByteFactoKey:
                   description: Defines the factor to be used for key/lookup generating fields.
                   type: integer
-            baseToken:
-              description: Gives info about the base token the network uses.
-              properties:
-                name:
-                  type: string
-                  description: The name of the base token of the network.
-                tickerSymbol:
-                  type: string
-                  description: Ticker symbol of the token to be displayed on trading platforms.
-                unit:
-                  type: string
-                  description: The primary unit of the token.
-                decimals:
-                  type: integer
-                  description: Number of decimals the primary unit is divisible up to.
-                subunit:
-                  type: string
-                  description: The name of the smallest possible denomination of the primary unit. subunit * 10^decimals = unit
-                "useMetricPrefix":
-                  type: boolean
-                  description: Wheteher to use metric prefixes for disaplying unit.
+              required:
+                - vByteCost
+                - vByteFactorData
+                - vByteFactoKey
           required:
             - networkName
             - bech32HRP
@@ -2942,7 +2924,33 @@ components:
             - protocolVersion
             - minPoWScore
             - rentStructure
-            - baseToken
+        baseToken:
+          description: Gives info about the base token the network uses.
+          properties:
+            name:
+              type: string
+              description: The name of the base token of the network.
+            tickerSymbol:
+              type: string
+              description: Ticker symbol of the token to be displayed on trading platforms.
+            unit:
+              type: string
+              description: The primary unit of the token.
+            decimals:
+              type: integer
+              description: Number of decimals the primary unit is divisible up to.
+            subunit:
+              type: string
+              description: The name of the smallest possible denomination of the primary unit. subunit * 10^decimals = unit
+            useMetricPrefix:
+              type: boolean
+              description: Wheteher to use metric prefixes for disaplying unit.
+          required:
+            - name
+            - tickerSymbol
+            - unit
+            - decimals
+            - useMetricPrefix
         features:
           description: The features that are supported by the node. For example, a node could support the Proof-of-Work (PoW) feature, which would allow the PoW to be performed by the node itself.
           type: array

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1109,7 +1109,7 @@ paths:
       tags:
         - control
       summary: Creates a new snapshot.
-      description: Creates a new snapshot
+      description: Creates a new snapshot.
       requestBody:
         content:
           application/json:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1426,6 +1426,7 @@ components:
           items:
             type: string
         payload:
+          description: The inner payload of the message. Can be nil.
           oneOf:
             - $ref: '#/components/schemas/TransactionPayload'
             - $ref: '#/components/schemas/MilestonePayload'
@@ -1437,7 +1438,6 @@ components:
       required:
         - protocolVersion
         - parentMessageIds
-        - payload
         - nonce
 
     TransactionPayload:
@@ -1477,11 +1477,13 @@ components:
           description: BLAKE2b-256 hash of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
         inputs:
           type: array
+          description: The inputs of this transaction.
           items:
             oneOf:
               - $ref: '#/components/schemas/UTXOInput'
         outputs:
           type: array
+          description: The outputs of this transaction.
           items:
             anyOf:
               - $ref: '#/components/schemas/BasicOutput'
@@ -1489,6 +1491,7 @@ components:
               - $ref: '#/components/schemas/FoundryOutput'
               - $ref: '#/components/schemas/NFTOutput'
         payload:
+          description: The optional embedded payload.
           oneOf:
             - $ref: '#/components/schemas/TaggedDataPayload'
           nullable: true
@@ -1498,7 +1501,6 @@ components:
         - inputsCommitment
         - inputs
         - outputs
-        - payload
 
     UTXOInput:
       description: Describes an input which references an unspent transaction output to consume.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -904,6 +904,8 @@ components:
         protocol:
           networkName: iota-testnet
           bech32HRP: atoi
+          tokenSupply: "2779530283277761"
+          protocolVersion: 2
           minPoWScore: 1000
           rentStructure:
             vByteCost: 500
@@ -2443,6 +2445,12 @@ components:
             bech32HRP:
               type: string
               description: Tells whether the node supports mainnet or testnet addresses. Value `iota` indicates that the node supports mainnet addresses. Value `atoi` indicates that the node supports testnet addresses.
+            tokenSupply:
+              type: string
+              description: Current supply of base token. Plain string encoded number.
+            protocolVersion:
+              type: integer
+              description: Protocol version used by the network.
             minPoWScore:
               description: The Proof-of-Work difficulty for a message to be sent over the network to mitigate spam.
               type: number
@@ -2462,6 +2470,8 @@ components:
           required:
             - networkName
             - bech32HRP
+            - tokenSupply
+            - protocolVersion
             - minPoWScore
             - rentStructure
         features:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2758,12 +2758,12 @@ components:
             code:
               type: string
               description: The application error code.
-            block:
+            message:
               type: string
               description: The error reason.
           required:
             - code
-            - block
+            - message
       required:
         - error
 
@@ -2774,7 +2774,7 @@ components:
       example:
         error:
           code: 403
-          block: not available for public use
+          message: not available for public use
 
     ServiceUnavailableResponse:
       description: Indicates that the service is unavailable.
@@ -2783,7 +2783,7 @@ components:
       example:
         error:
           code: 503
-          block: service unavailable
+          message: service unavailable
 
     BadRequestResponse:
       description: Indicates that the request was bad.
@@ -2792,7 +2792,7 @@ components:
       example:
         error:
           code: 400
-          block: invalid data provided
+          message: invalid data provided
 
     NotFoundResponse:
       description: Indicates that the data was not found.
@@ -2801,7 +2801,7 @@ components:
       example:
         error:
           code: 404
-          block: could not find data
+          message: could not find data
 
     InternalErrorResponse:
       description: Indicates that the server encountered an unexpected condition, which prevented it from fulfilling the request by the client.
@@ -2810,7 +2810,7 @@ components:
       example:
         error:
           code: 500
-          block: internal server error
+          message: internal server error
 
     InfoResponse:
       description: Returns general information about the node.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1547,7 +1547,7 @@ components:
         type: 7
         index: 15465
         timestamp: 1602227215
-        lastMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
+        previousMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         parentMessageIds:
          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
          - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -1699,7 +1699,7 @@ components:
           - "0x5807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c"
           - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
           - "0xde9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652"
-        lastMilestoneId: "0x733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d"
+        previousMilestoneId: "0x733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d"
 
     compute-whiteflag-response-example:
       value:
@@ -2363,7 +2363,7 @@ components:
         timestamp:
           type: integer
           description: The Unix timestamp at which the milestone was issued. The unix timestamp is specified in seconds.
-        lastMilestoneId:
+        previousMilestoneId:
           type: string
           description: The Milestone ID of the milestone with Index Number - 1.
         parentMessageIds:
@@ -2396,7 +2396,7 @@ components:
         - type
         - index
         - timestamp
-        - lastMilestoneId
+        - previousMilestoneId
         - parentMessageIds
         - confirmedMerkleRoot
         - appliedMerkleRoot
@@ -3133,14 +3133,14 @@ components:
           description: The hex encoded message IDs of the parents the milestone references.
           items:
             type: string
-        lastMilestoneId:
+        previousMilestoneId:
           type: string
           description: The hex encoded milestone ID of the previous milestone.
       required:
         - index
         - timestamp
         - parentMessageIds
-        - lastMilestoneId
+        - previousMilestoneId
 
     ComputeWhiteFlagResponse:
       description: Returns the computed ConfirmedMerkleRoot and AppliedMerkleRoot

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1192,7 +1192,7 @@ components:
           networkName: iota-testnet
           bech32Hrp: atoi
           tokenSupply: "2779530283277761"
-          protocolVersion: 2
+          version: 2
           minPowScore: 1000
           rentStructure:
             vByteCost: 500
@@ -1245,7 +1245,7 @@ components:
           networkName: shimmer-testnet
           bech32Hrp: rms
           tokenSupply: "2779530283277761"
-          protocolVersion: 2
+          version: 2
           minPowScore: 1000
           rentStructure:
             vByteCost: 500
@@ -2931,7 +2931,7 @@ components:
             tokenSupply:
               type: string
               description: Current supply of base token. Plain string encoded number.
-            protocolVersion:
+            version:
               type: integer
               description: Protocol version used by the network.
             minPowScore:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1060,7 +1060,7 @@ paths:
       tags:
         - control
       summary: Prunes the node database.
-      description: Prunes the node database..
+      description: Prunes the node database.
       requestBody:
         content:
           application/json:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2983,7 +2983,7 @@ components:
               description: The name of the smallest possible denomination of the primary unit. subunit * 10^decimals = unit
             useMetricPrefix:
               type: boolean
-              description: Wheteher to use metric prefixes for disaplying unit.
+              description: Whether to use metric prefixes for displaying unit.
           required:
             - name
             - tickerSymbol
@@ -3022,7 +3022,7 @@ components:
       properties:
         protocolVersion:
           type: integer
-          description: Protocol version number of the block.It also tells which protocol rules apply to the block.
+          description: Protocol version number of the block. It also tells which protocol rules apply to the block.
         parents:
           type: array
           description: The identifiers of the blocks this block references. Hex-encoded with 0x prefix.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2534,7 +2534,7 @@ components:
           description: Set to value 5 to denote a Tagged Data Payload.
         tag:
           type: string
-          description: The indexation key to allow external tools to find/look up this block. It has a size between 1 and 64 bytes and must be encoded as a hex-string with 0x prefix.
+          description: The tag to allow external tools to find/look up this block. It has a size between 1 and 64 bytes and must be encoded as a hex-string with 0x prefix. Network nodes do not index blocks with Tagged Data Payload by the tag field by default.
         data:
           type: string
           description: The optional data to attach. This may have a length of 0. Hex-encoded with 0x prefix.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2540,8 +2540,6 @@ components:
           description: The optional data to attach. This may have a length of 0. Hex-encoded with 0x prefix.
       required:
         - type
-        - tag
-        - data
 
     TreasuryTransactionPayload:
       properties:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -3309,25 +3309,21 @@ components:
     CreateSnapshotRequest:
       description: Defines the request of a create snapshots REST API call.
       properties:
-        fullIndex:
+        index:
           type: integer
-          description: The index of the full snapshot.
-        deltaIndex:
-          type: integer
-          description: The index of the delta snapshot.
+          description: The index of the snapshot.
+      required:
+        - index
 
     CreateSnapshotResponse:
       description: Defines the request of a create snapshots REST API call.
       properties:
-        fullIndex:
+        index:
           type: integer
-          description: The index of the full snapshot.
-        deltaIndex:
-          type: integer
-          description: The index of the delta snapshot.
-        fullFilePath:
+          description: The index of the snapshot.
+        filePath:
           type: string
-          description: The file path of the full snapshot file.
-        deltaFilePath:
-          type: string
-          description: The file path of the delta snapshot file.
+          description: The file path of the snapshot file.
+      required:
+        - index
+        - filePath

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2875,8 +2875,6 @@ components:
                   description: The Milestone ID of the latest seen milestone. Hex-encoded with 0x prefix.
               required:
                 - index
-                - timestamp
-                - milestoneId
             confirmedMilestone:
               type: object
               description: Information about the latest confirmed milestone.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1536,13 +1536,14 @@ components:
 
     get-outputs-by-id-response-unspent-example:
       value:
-        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
-        transactionId: "0x1ee46e19f4219ee65afc10227d0ca22753f76ef32d1e922e5cbe3fbc9b5a5298"
-        outputIndex: 1
-        isSpent: false
-        milestoneIndexBooked: 1234567
-        milestoneTimestampBooked: 1643207146
-        ledgerIndex: 946704
+        metadata:
+          messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+          transactionId: "0x1ee46e19f4219ee65afc10227d0ca22753f76ef32d1e922e5cbe3fbc9b5a5298"
+          outputIndex: 1
+          isSpent: false
+          milestoneIndexBooked: 1234567
+          milestoneTimestampBooked: 1643207146
+          ledgerIndex: 946704
         output:
           type: 3
           amount: "1000"
@@ -1554,16 +1555,17 @@ components:
 
     get-outputs-by-id-response-spent-example:
       value:
-        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
-        transactionId: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a2"
-        outputIndex: 1
-        isSpent: true
-        milestoneIndexSpent: 1234570
-        milestoneTimestampSpent: 1643207176
-        transactionIdSpent: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
-        milestoneIndexBooked: 1234567
-        milestoneTimestampBooked: 1643207146
-        ledgerIndex: 946704
+        metadata:
+          messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+          transactionId: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a2"
+          outputIndex: 1
+          isSpent: true
+          milestoneIndexSpent: 1234570
+          milestoneTimestampSpent: 1643207176
+          transactionIdSpent: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
+          milestoneIndexBooked: 1234567
+          milestoneTimestampBooked: 1643207146
+          ledgerIndex: 946704
         output:
           type: 3
           amount: "1000"
@@ -3101,56 +3103,22 @@ components:
         - childrenMessageIds
 
     OutputResponse:
-      description: Returns an output.
+      description: Returns an output and its metadata.
       properties:
-        messageId:
-          type: string
-          description: The message identifier that references the output. Hex-encoded with 0x prefix.
-        transactionId:
-          type: string
-          description: The identifier of the transaction. Hex-encoded with 0x prefix.
-        outputIndex:
-          type: integer
-          description: The index of the output.
-        isSpent:
-          type: boolean
-          description: Tells if the output is spent or not.
-        milestoneIndexSpent:
-          type: integer
-          description: The milestone index at which this output was spent.
-          nullable: true
-        milestoneTimestampSpent:
-          type: integer
-          description: The milestone timestamp this output was spent.
-          nullable: true
-        transactionIdSpent:
-          type: string
-          description: The transaction this output was spent with. Hex-encoded with 0x prefix.
-          nullable: true
-        milestoneIndexBooked:
-          type: integer
-          description: The milestone index at which the output was booked.
-        milestoneTimestampBooked:
-          type: integer
-          description: The milestone unix timestamp at which the output was booked.
-        ledgerIndex:
-          type: integer
-          description: The current ledger index for which the request was made.
+        metadata:
+          description: Metadata of the output.
+          allOf:
+            - $ref: '#components/schemas/OutputMetadataResponse'
         output:
+          description: The actual output content.
           anyOf:
             - $ref: '#/components/schemas/BasicOutput'
             - $ref: '#/components/schemas/AliasOutput'
             - $ref: '#/components/schemas/FoundryOutput'
             - $ref: '#/components/schemas/NFTOutput'
       required:
-        - messageId
-        - transactionId
-        - outputIndex
-        - isSpent
-        - milestoneIndexBooked
-        - milestoneTimestampBooked
+        - metadata
         - output
-        - ledgerIndex
 
     OutputMetadataResponse:
       description: Returns metadata about an output.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2890,8 +2890,6 @@ components:
                   description: The Milestone ID of the latest confirmed milestone. Hex-encoded with 0x prefix.
               required:
                 - index
-                - timestamp
-                - milestoneId
           required:
             - isHealthy
             - latestMilestone

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -50,7 +50,31 @@ paths:
         '503':
           description: "Unsuccessful operation: indicates that the node isn´t healthy."
 
-  /api/v2/info:
+  /api/routes:
+    get:
+      tags:
+        - node
+      summary: Returns the available API route groups of the node.
+      description: >-
+        Returns the available API route groups of the node.
+      responses:
+        '200':
+          description: "Successful operation"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutesResponse'
+              examples:
+                default:
+                  $ref: '#/components/examples/get-routes-response-example'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+        '503':
+          description: "Unsuccessful operation: indicates that the node isn´t healthy."
+
+  /api/core/v2/info:
     get:
       tags:
         - node
@@ -81,7 +105,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/v2/tips:
+  /api/core/v2/tips:
     get:
       tags:
         - tangle
@@ -117,7 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  /api/v2/blocks:
+  /api/core/v2/blocks:
     post:
       tags:
         - blocks
@@ -190,7 +214,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/blocks/{blockId}':
+  '/api/core/v2/blocks/{blockId}':
     get:
       tags:
         - blocks
@@ -257,7 +281,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/blocks/{blockId}/metadata':
+  '/api/core/v2/blocks/{blockId}/metadata':
     get:
       tags:
         - blocks
@@ -322,7 +346,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  '/api/v2/outputs/{outputId}':
+  '/api/core/v2/outputs/{outputId}':
     get:
       tags:
         - UTXO
@@ -381,7 +405,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/outputs/{outputId}/metadata':
+  '/api/core/v2/outputs/{outputId}/metadata':
     get:
       tags:
         - UTXO
@@ -434,7 +458,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/receipts':
+  '/api/core/v2/receipts':
     get:
       tags:
         - UTXO
@@ -475,7 +499,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/receipts/{migratedAt}':
+  '/api/core/v2/receipts/{migratedAt}':
     get:
       tags:
         - UTXO
@@ -525,7 +549,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  '/api/v2/treasury':
+  '/api/core/v2/treasury':
     get:
       tags:
         - UTXO
@@ -567,7 +591,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
 
-  '/api/v2/transactions/{transactionId}/included-block':
+  '/api/core/v2/transactions/{transactionId}/included-block':
     get:
       tags:
         - UTXO
@@ -623,7 +647,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/milestones/{milestoneId}':
+  '/api/core/v2/milestones/{milestoneId}':
     get:
       tags:
         - milestones
@@ -681,7 +705,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/milestones/{milestoneId}/utxo-changes':
+  '/api/core/v2/milestones/{milestoneId}/utxo-changes':
     get:
       tags:
         - milestones
@@ -730,7 +754,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/milestones/by-index/{index}':
+  '/api/core/v2/milestones/by-index/{index}':
     get:
       tags:
         - milestones
@@ -788,7 +812,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/milestones/by-index/{index}/utxo-changes':
+  '/api/core/v2/milestones/by-index/{index}/utxo-changes':
     get:
       tags:
         - milestones
@@ -839,7 +863,7 @@ paths:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
 
-  /api/v2/peers:
+  /api/core/v2/peers:
     get:
       tags:
         - peers
@@ -909,7 +933,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/peers/{peerId}':
+  '/api/core/v2/peers/{peerId}':
     get:
       tags:
         - peers
@@ -982,7 +1006,7 @@ paths:
         '500':
           description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
 
-  '/api/v2/whiteflag':
+  '/api/core/v2/whiteflag':
     post:
       tags:
         - milestones
@@ -1031,7 +1055,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/control/database/prune':
+  '/api/core/v2/control/database/prune':
     post:
       tags:
         - control
@@ -1080,7 +1104,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/control/snapshot/create':
+  '/api/core/v2/control/snapshot/create':
     post:
       tags:
         - control
@@ -1135,6 +1159,12 @@ paths:
 
 components:
   examples:
+    get-routes-response-example:
+      value:
+        routes:
+          - "core/v2"
+          - "dashboard-metrics/v1"
+          - "debug/v1"
     get-info-response-example:
       value:
         name: HORNET
@@ -2807,6 +2837,16 @@ components:
           code: 500
           message: internal server error
 
+    RoutesResponse:
+      description: Contains the available API routes of the node.
+      properties:
+        routes:
+          type: array
+          items:
+            type: string
+      required:
+        - routes
+
     InfoResponse:
       description: Returns general information about the node.
       properties:
@@ -3299,7 +3339,7 @@ components:
         fullIndex:
           type: integer
           description: The index of the full snapshot.
-        delatIndex:
+        deltaIndex:
           type: integer
           description: The index of the delta snapshot.
 
@@ -3309,7 +3349,7 @@ components:
         fullIndex:
           type: integer
           description: The index of the full snapshot.
-        delatIndex:
+        deltaIndex:
           type: integer
           description: The index of the delta snapshot.
         fullFilePath:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -636,7 +636,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/milestones/{index}':
+  '/api/v2/milestones/index/{index}':
     get:
       tags:
         - milestones
@@ -656,11 +656,61 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MilestoneResponse'
+                $ref: '#/components/schemas/MilestonePayload'
               examples:
                 default:
                   $ref: >-
-                    #/components/examples/get-milestone-by-index-response-example
+                    #/components/examples/get-milestone-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  '/api/v2/milestones/milestoneId/{milestoneId}':
+    get:
+      tags:
+        - milestones
+      summary: Look up a milestone by a given milestone ID.
+      description: Look up a milestone by a given milestone ID.
+      parameters:
+        - in: path
+          name: milestoneId
+          schema:
+            type: string
+          example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
+          required: true
+          description: Milestone ID of the milestone to look up.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MilestonePayload'
+              examples:
+                default:
+                  $ref: >-
+                    #/components/examples/get-milestone-response-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -1252,7 +1302,7 @@ components:
         milestoneId: "0x733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d"
         amount: "133713371337"
 
-    get-included-message-of-transaction-example:
+    get-included-message-of-transaction-example-json:
       value:
         protocolVersion: 1
         parentMessageIds:
@@ -1271,10 +1321,12 @@ components:
                 transactionId: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
                 transactionOutputIndex: 0
             outputs:
-              - type: 0
-                address:
+              - type: 3
+                unlockConditions:
                   type: 0
-                  pubKeyHash: "0xa18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b"
+                  address:
+                    type: 0
+                    pubKeyHash: "0xa18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b"
                 amount: "1000000"
             payload:
               type: 2
@@ -1288,11 +1340,28 @@ components:
                 signature: "0x0492a353f96883c472e2686a640e77eda30be8fcc417aa9fc1c15eae854661e0253287be6ea68f649f19ca590de0a6c57fb88635ef0e013310e0be2b83609503"
         nonce: '17293822569102719312'
 
-    get-milestone-by-index-response-example:
+    get-milestone-response-example:
       value:
+        type: 7
         index: 15465
         messageId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         timestamp: 1602227215
+        parentMessageIds:
+         - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
+         - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
+         - "0xde9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652"
+        confirmedMerkleRoot: "0xa18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b"
+        appliedMerkleRoot: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
+        options:
+         - type: 1
+           nextPoWScore: 2000
+           nextPoWScoreMilestoneIndex: 15475
+        metadata: "0xd6ac43e9ca750"
+        signatures:
+          - type: 0
+            publickKey: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
+            signature: "0x0492a353f96883c472e2686a640e77eda30be8fcc417aa9fc1c15eae854661e0253287be6ea68f649f19ca590de0a6c57fb88635ef0e013310e0be2b83609503"
+
 
     get-utxo-changes-response-example:
       value:
@@ -2050,42 +2119,39 @@ components:
         timestamp:
           type: integer
           description: The Unix timestamp at which the milestone was issued. The unix timestamp is specified in seconds.
-        parents:
+        parentMessageIds:
           description: The identifiers of the messages this milestone references. Hex-encoded values with 0x prefix.
           type: array
           items:
             type: string
-        inclusionMerkleProof:
+        confirmedMerkleRoot:
           type: string
-          description: 256-bit hash based on the message IDs of all the not-ignored state-mutating transactions referenced by the milestone. Hex-encoded with 0x prefix.
-        nextPoWScore:
-          type: number
-          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
-        nextPoWScoreMilestoneIndex:
-          description: The milestone index at which the PoW score changes to NextPoWScore.
-          type: number
+          description: The merkle root of all directly/indirectly referenced messages (their IDs) which are newly confirmed by this milestone. Hex-encoded with 0x prefix.
+        appliedMerkleRoot:
+          type: string
+          description: The merkle root of all messages (their IDs) carrying ledger state mutating transactions. Hex-encoded with 0x prefix.
+        options:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ReceiptPayload'
+              - $ref: '#/components/schemas/ProtocolParamsMilestoneOpt'
         metadata:
           type: string
           description: Hex-encoded binary data with 0x prefix.
-        receipt:
-          type: object
-          description: The inner receipt payload of the milestone. Can be nil or a Receipt.
-          oneOf:
-            - $ref: '#/components/schemas/ReceiptPayload'
         signatures:
           type: array
           items:
-            type: string
-          description: An array of signatures signing the serialized Milestone Essence. The signatures must be in the same order as the specified public keys. Hex-encoded with 0x prefix.
+            anyOf:
+              - $ref: '#/components/schemas/Ed25519Signature'
+          description: An array of signatures signing the serialized Milestone Essence. Hex-encoded with 0x prefix.
       required:
         - type
         - index
         - timestamp
-        - parents
-        - inclusionMerkleProof
-        - nextPoWScore
-        - nextPoWScoreMilestoneIndex
-        - publicKeys
+        - parentMessageIds
+        - confirmedMerkleRoot
+        - appliedMerkleRoot
         - signatures
 
     TaggedDataPayload:
@@ -2256,6 +2322,20 @@ components:
         - sentMilestoneRequests
         - sentHeartbeats
         - droppedPackets
+
+    ProtocolParamsMilestoneOpt:
+      description: Defines changing protocol parameters in a milestone.
+      properties:
+        type:
+          type: integer
+          description: Defines the type of MilestoneOpt.
+        nextPoWScore:
+          type: integer
+          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
+        nextPoWScoreMilestoneIndex:
+          type: integer
+          description: The milestone index at which the PoW score changes to NextPoWScore.
+
 
     ReceiptTuple:
       description: Contains a receipt and the index of the milestone which contained the receipt.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -667,56 +667,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  '/api/v2/milestones/index/{index}':
-    get:
-      tags:
-        - milestones
-      summary: Look up a milestone by a given milestone index.
-      description: Look up a milestone by a given milestone index.
-      parameters:
-        - in: path
-          name: index
-          schema:
-            type: number
-          example: 154862
-          required: true
-          description: Index of the milestone to look up.
-      responses:
-        '200':
-          description: "Successful operation."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MilestonePayload'
-              examples:
-                default:
-                  $ref: >-
-                    #/components/examples/get-milestone-response-example
-        '400':
-          description: "Unsuccessful operation: indicates that the provided data is invalid."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '403':
-          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-        '404':
-          description: "Unsuccessful operation: indicates that the requested data was not found."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/milestones/milestoneId/{milestoneId}':
+  '/api/v2/milestones/{milestoneId}':
     get:
       tags:
         - milestones
@@ -741,6 +692,15 @@ paths:
                 default:
                   $ref: >-
                     #/components/examples/get-milestone-response-example
+            application/vnd.iota.serializer-v1:
+              schema:
+                type: string
+                format: binary
+                description: Milestone payload in raw binary format
+              examples:
+                default:
+                  $ref: >-
+                    #/components/examples/get-milestone-response-binary-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -765,12 +725,119 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  '/api/v2/milestones/{index}/utxo-changes':
+  '/api/v2/milestones/{milestoneId}/utxo-changes':
     get:
       tags:
         - milestones
-      summary: Get all UTXO changes of a given milestone.
-      description: Get all UTXO changes of a given milestone.
+      summary: Get all UTXO changes of a given milestone by milestone ID.
+      description: Get all UTXO changes of a given milestone by Milestone ID.
+      parameters:
+        - in: path
+          name: milestoneId
+          schema:
+            type: string
+          example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
+          required: true
+          description: Milestone ID of the milestone to look up.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UTXOChangesResponse'
+              examples:
+                default:
+                  $ref: >-
+                    #/components/examples/get-utxo-changes-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+  '/api/v2/milestones/by-index/{index}':
+    get:
+      tags:
+        - milestones
+      summary: Look up a milestone by a given milestone index.
+      description: Look up a milestone by a given milestone index.
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: number
+          example: 154862
+          required: true
+          description: Index of the milestone to look up.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MilestonePayload'
+              examples:
+                default:
+                  $ref: >-
+                    #/components/examples/get-milestone-response-example
+            application/vnd.iota.serializer-v1:
+              schema:
+                type: string
+                format: binary
+                description: Milestone payload in raw binary format
+              examples:
+                default:
+                  $ref: >-
+                    #/components/examples/get-milestone-response-binary-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+  '/api/v2/milestones/by-index/{index}/utxo-changes':
+    get:
+      tags:
+        - milestones
+      summary: Get all UTXO changes of a given milestone by milestone index.
+      description: Get all UTXO changes of a given milestone by milestone index.
       parameters:
         - in: path
           name: index
@@ -814,6 +881,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
+
 
   /api/v2/peers:
     get:
@@ -1564,6 +1632,8 @@ components:
             publickKey: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
             signature: "0x0492a353f96883c472e2686a640e77eda30be8fcc417aa9fc1c15eae854661e0253287be6ea68f649f19ca590de0a6c57fb88635ef0e013310e0be2b83609503"
 
+    get-milestone-response-binary-example:
+      value: "070000000a1a0000977c626276b19ef8b3c445709f2f0f2ccc4abb98d97617f421f240c0d1ee066d4306e67a0321889ef8ec89b7eff1378049e058f0fa87a78c2452ae72631a5a99d913d1cbb3525b8faa1800e28dfcb28154bcba10154c39ef87ceda793cb44f58ae1549c88ea13fe4a9695bb6f0aba6cb756522209e5066a96039ae12b398b975693bdc21e222997c86ff9bfc5844f0372d58ff6fa510688e53c181bbdf4db41f9b627540a70e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a80000000300d85e5b1590d898d1e0cdebb2e3b5337c8b76270142663d78811683ba47c17c989ad7a8f0ff2c6438bf435786d4a5b0125a5caf7367061b49a739389d5ebea234c0466c86f88a3f8add03bff04c2e34b214683f2f6983641e1d1185da7e2c3e0200d9922819a39e94ddf3907f4b9c8df93f39f026244fcb609205b9a879022599f218be2536d8b7b8547faa3dbdfe98339ebe9e2b2417a8a03eee02b2a8312b9e026dd0a33261a58a240cd0a1b06cdf1775d98d316f162d3eec402f4bf08bea2a0700f9d9656a60049083eef61487632187b351294c1fa23d118060d813db6d03e8b6ca8180d435708e826bc2042ccd667babb59c5cc461ff29dba966359fcd6fc511cdfdf10d6576f36ac2a6e5cb691e13968c13947ffbd9239939d3802b2fbe0f06"
 
     get-utxo-changes-response-example:
       value:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1274,8 +1274,6 @@ components:
           useMetricPrefix: false
         features:
           - PoW
-        plugins:
-          - indexer/v1
 
     get-tips-response-example:
       value:
@@ -3003,11 +3001,6 @@ components:
           type: array
           items:
             type: string
-        plugins:
-          description: The plugins this node exposes. For example, a node could run the indexer application and provide an indexer api.
-          type: array
-          items:
-            type: string
       required:
         - name
         - version
@@ -3018,7 +3011,6 @@ components:
         - pendingProtocolParameters
         - baseToken
         - features
-        - plugins
 
     TipsResponse:
       description: Returns tips that are ideal for attaching a block.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -555,7 +555,7 @@ paths:
         - UTXO
       summary: Returns information about the treasury.
       description: >-
-        Returns information about the treasury. The treasury hold the unmigrated tokens from the Legacy Mainnet.
+        Returns information about the treasury. For the IOTA Mainnet, the treasury holds the unmigrated tokens from the Legacy IOTA Mainnet.
       responses:
         '200':
           description: "Successful operation."

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1915,7 +1915,7 @@ components:
           description: Network identifier. Plain string encoded number. This field signals for which network the block is meant for. It is computed out of the first 8 bytes of the `BLAKE2b-256` hash of the concatenation of the network name and protocol version string.
         inputsCommitment:
           type: string
-          description: BLAKE2b-256 hash of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
+          description: BLAKE2b-256 hash of the BLAKE2b-256 hash of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
         inputs:
           type: array
           description: The inputs of this transaction.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1633,15 +1633,6 @@ components:
         tokenTag:
           type: string
           description: Hex-encoded data with 0x prefix that is always the last 12 bytes of ID of the tokens produced by this foundry.
-        mintedTokens:
-          type: string
-          description: Minted tokens controlled by this foundry. Hex-encoded number with 0x prefix.
-        meltedTokens:
-          type: string
-          description: Melted tokens controlled by this foundry. Hex-encoded number with 0x prefix.
-        maxSupply:
-          type: string
-          description: Maximum supply of tokens controlled by this foundry. Hex-encoded number with 0x prefix.
         tokenScheme:
           type: array
           description: Defines the supply control scheme of the tokens controlled by the foundry.
@@ -1672,9 +1663,6 @@ components:
         - amount
         - serialNumber
         - tokenTag
-        - mintedTokens
-        - meltedTokens
-        - maxSupply
         - tokenScheme
         - unlockConditions
 
@@ -1920,6 +1908,20 @@ components:
         type:
           type: integer
           description: Set to value 0 to denote an Simple Token Scheme.
+        mintedTokens:
+          type: string
+          description: Minted tokens controlled by this foundry. Hex-encoded number with 0x prefix.
+        meltedTokens:
+          type: string
+          description: Melted tokens controlled by this foundry. Hex-encoded number with 0x prefix.
+        maxSupply:
+          type: string
+          description: Maximum supply of tokens controlled by this foundry. Hex-encoded number with 0x prefix.
+      required:
+        - type
+        - mintedTokens
+        - meltedTokens
+        - maxSupply
 
     SignatureUnlockBlock:
       description: Defines an unlock block containing signature(s) unlocking input(s).

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -204,10 +204,6 @@ paths:
           example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           required: true
           description: Identifier of the message.
-      requestBody:
-        content:
-          application/json: {}
-          application/vnd.iota.serializer-v1: {}
       responses:
         '200':
           description: "Successful operation."
@@ -386,10 +382,6 @@ paths:
             Identifier of the output encoded in hex. An output is identified by
             the concatenation of `transactionId+outputIndex`. Hex-encoded with 0x prefix.
           example: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a20100"
-      requestBody:
-        content:
-          application/json: {}
-          application/vnd.iota.serializer-v1: {}
       responses:
         '200':
           description: "Successful operation."
@@ -633,10 +625,6 @@ paths:
           example: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
           required: true
           description: Identifier of the transaction to look up.
-      requestBody:
-        content:
-          application/json: { }
-          application/vnd.iota.serializer-v1: { }
       responses:
         '200':
           description: "Successful operation."
@@ -3103,7 +3091,7 @@ components:
       description: Returns all peers of the node.
       type: array
       items:
-        - $ref: '#/components/schemas/Peer'
+        $ref: '#/components/schemas/Peer'
 
     PeerResponse:
       description: Returns a given peer of the node.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -888,9 +888,14 @@ components:
         version: 0.6.0-alpha
         status:
           isHealthy: true
-          latestMilestoneTimestamp: 1617802102
-          latestMilestoneIndex: 480
-          confirmedMilestoneIndex: 480
+          latestMilestone:
+            index: 480
+            timestamp: 1617802102
+            milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
+          confirmedMilestone:
+            index: 480
+            timestamp: 1617802102
+            milestoneId: "0xb59ff329113b0da14343707450cb28d41fa18b295deabc4beb3fc1b6e70f9d9e"
           pruningIndex: 0
         metrics:
           messagesPerSecond: 17
@@ -2376,18 +2381,40 @@ components:
             isHealthy:
               type: boolean
               description: Tells whether the node is healthy or not.
-            latestMilestoneTimestamp:
-              type: integer
-              description: The timestamp of the latest seen milestone.
-            latestMilestoneIndex:
-              type: integer
-              description: The most recent milestone known to the node.
-            confirmedMilestoneIndex:
-              type: integer
-              description: The most recent milestone that has been confirmed by the node.
-            pruningIndex:
-              type: integer
-              description: Tells from which starting point the node holds data.
+            latestMilestone:
+              type: object
+              description: Information about the latest seen milestone.
+              properties:
+                index:
+                  type: integer
+                  description: The index of the latest seen milestone.
+                timestamp:
+                  type: integer
+                  description: The timestamp of the latest seen milestone.
+                milestoneId:
+                  type: string
+                  description: The Milestone ID of the latest seen milestone. Hex-encoded with 0x prefix.
+              required:
+                - index
+                - timestamp
+                - milestoneId
+            confirmedMilestone:
+              type: object
+              description: Information about the latest confirmed milestone.
+              properties:
+                index:
+                  type: integer
+                  description: The index of the latest confirmed milestone.
+                timestamp:
+                  type: integer
+                  description: The timestamp of the latest confirmed milestone.
+                milestoneId:
+                  type: string
+                  description: The Milestone ID of the latest confirmed milestone. Hex-encoded with 0x prefix.
+              required:
+                - index
+                - timestamp
+                - milestoneId
         metrics:
           description: Node metrics.
           properties:
@@ -2403,6 +2430,10 @@ components:
               description: The ratio of referenced messages in relation to new messages of the last confirmed milestone.
               type: number
               format: float
+          required:
+            - messagesPerSecond
+            - referencedMessagesPerSecond
+            - referencedRate
         protocol:
           description: Protocol parameters.
           properties:
@@ -2428,6 +2459,11 @@ components:
                 vByteFactoKey:
                   description: Defines the factor to be used for key/lookup generating fields.
                   type: integer
+          required:
+            - networkName
+            - bech32HRP
+            - minPoWScore
+            - rentStructure
         features:
           description: The features that are supported by the node. For example, a node could support the Proof-of-Work (PoW) feature, which would allow the PoW to be performed by the node itself.
           type: array

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1992,6 +1992,8 @@ components:
       required:
         - type
         - amount
+        - nativeTokens
+        - featureBlocks
         - unlockConditions
 
     AliasOutput:
@@ -2047,9 +2049,12 @@ components:
       required:
         - type
         - amount
+        - nativeTokens
         - aliasId
         - stateIndex
         - foundryCounter
+        - featureBlocks
+        - immutableFeatureBlocks
         - unlockConditions
 
     FoundryOutput:
@@ -2101,10 +2106,13 @@ components:
       required:
         - type
         - amount
+        - nativeTokens
         - serialNumber
         - tokenTag
         - tokenScheme
         - unlockConditions
+        - featureBlocks
+        - immutableFeatureBlocks
 
     NFTOutput:
       description: escribes an NFT output, a globally unique token with metadata attached.
@@ -2153,8 +2161,11 @@ components:
       required:
         - type
         - amount
+        - nativeTokens
         - nftId
         - unlockConditions
+        - featureBlocks
+        - immutableFeatureBlocks
 
     NativeToken:
       description: A native token and its balance in the output.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1915,7 +1915,7 @@ components:
           description: Network identifier. Plain string encoded number. This field signals for which network the block is meant for. It is computed out of the first 8 bytes of the `BLAKE2b-256` hash of the concatenation of the network name and protocol version string.
         inputsCommitment:
           type: string
-          description: BLAKE2b-256 hash of the BLAKE2b-256 hash of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
+          description: BLAKE2b-256 hash of the BLAKE2b-256 hashes of the serialized outputs referenced in Inputs by their outputIds (transactionId || outputIndex). Hex-encoded data with 0x prefix.
         inputs:
           type: array
           description: The inputs of this transaction.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2702,6 +2702,11 @@ components:
         params:
           type: string
           description: The protocol parameters in binary form. Hex-encoded with 0x prefix.
+      required:
+        - type
+        - targetMilestoneIndex
+        - protocolVersion
+        - params
 
     ReceiptTuple:
       description: Contains a receipt and the index of the milestone which contained the receipt.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2645,6 +2645,12 @@ components:
         syncedNeighbors:
           type: integer
           description: Tells how many synced peers the node has.
+      required:
+        - solidMilestoneIndex
+        - prunedMilestoneIndex
+        - latestMilestoneIndex
+        - connectedNeighbors
+        - syncedNeighbors
 
     Metrics:
       properties:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1674,8 +1674,9 @@ components:
         appliedMerkleRoot: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
         options:
          - type: 1
-           nextPoWScore: 2000
-           nextPoWScoreMilestoneIndex: 15475
+           targetMilestoneIndex: 2000
+           protocolVersion: 13
+           params: "0x27d0ca22753f76ef32d1e9e8fcc417aa9fc1c15eae854661e0253287be6ea68f649493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d6"
         metadata: "0xd6ac43e9ca750"
         signatures:
           - type: 0
@@ -2692,13 +2693,15 @@ components:
         type:
           type: integer
           description: Defines the type of MilestoneOpt.
-        nextPoWScore:
+        targetMilestoneIndex:
           type: integer
-          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
-        nextPoWScoreMilestoneIndex:
+          description: The milestone index at which these protocol parameters become active.
+        protocolVersion:
           type: integer
-          description: The milestone index at which the PoW score changes to NextPoWScore.
-
+          description: The to be applied protocol version.
+        params:
+          type: string
+          description: The protocol parameters in binary form. Hex-encoded with 0x prefix.
 
     ReceiptTuple:
       description: Contains a receipt and the index of the milestone which contained the receipt.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -47,6 +47,7 @@ paths:
           description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
         '503':
           description: "Unsuccessful operation: indicates that the node isn´t healthy."
+
   /api/v2/info:
     get:
       tags:
@@ -75,6 +76,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
+
   /api/v2/tips:
     get:
       tags:
@@ -110,6 +112,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
+
   /api/v2/messages:
     post:
       tags:
@@ -138,7 +141,7 @@ paths:
               Minimal Message with Transaction Payload:
                 $ref: >-
                   #/components/examples/post-transaction-message-request-example-minimal
-          application/octet-stream:
+          application/vnd.iota.serializer-v1:
             schema:
               type: string
               format: binary
@@ -154,6 +157,11 @@ paths:
               examples:
                 default:
                   $ref: '#/components/examples/post-messages-response-example'
+          headers:
+            Location:
+              description: The messageId of the newly created message.
+              schema:
+                type: string
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -194,6 +202,10 @@ paths:
           example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
           required: true
           description: Identifier of the message.
+      requestBody:
+        content:
+          application/json: {}
+          application/vnd.iota.serializer-v1: {}
       responses:
         '200':
           description: "Successful operation."
@@ -214,6 +226,13 @@ paths:
                 Tagged Data Payload:
                   $ref: >-
                     #/components/examples/get-message-by-id-tagged-data-response-example
+            application/vnd.iota.serializer-v1:
+              schema:
+                type: string
+                format: binary
+                description: message in raw binary format
+                example: >-
+                  0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -302,56 +321,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-  '/api/v2/messages/{messageId}/raw':
-    get:
-      tags:
-        - messages
-      summary: Returns message raw bytes by its identifier.
-      description: >-
-        Find a message by its identifier. This endpoint returns the given message
-        raw data.
-      parameters:
-        - in: path
-          name: messageId
-          schema:
-            type: string
-          example: "0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d"
-          required: true
-          description: Identifier of the message.
-      responses:
-        '200':
-          description: "Successful operation."
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-              example: >-
-                0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
-        '400':
-          description: "Unsuccessful operation: indicates that the provided data is invalid."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '403':
-          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-        '404':
-          description: "Unsuccessful operation: indicates that the requested data was not found."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalErrorResponse'
   '/api/v2/messages/{messageId}/children':
     get:
       tags:
@@ -392,6 +361,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  '/api/v2/outputs/{outputId}':
+    get:
+      tags:
+        - UTXO
+      summary: Find an output by its identifier.
+      description: Find an output by its identifier.
+      parameters:
+        - in: path
+          name: outputId
+          schema:
+            type: string
+          required: true
+          description: >-
+            Identifier of the output encoded in hex. An output is identified by
+            the concatenation of `transactionId+outputIndex`. Hex-encoded with 0x prefix.
+          example: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a20100"
+      requestBody:
+        content:
+          application/json: {}
+          application/vnd.iota.serializer-v1: {}
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputResponse'
+              examples:
+                unspent:
+                  $ref: '#/components/examples/get-outputs-by-id-response-unspent-example'
+                spent:
+                  $ref: '#/components/examples/get-outputs-by-id-response-spent-example'
+            application/vnd.iota.serializer-v1:
+              schema:
+                type: string
+                format: binary
+                description: output in raw binary format
+                example: >-
+                  0440420f00000000000004056b0c542e18ac5f44a1c13c5922564b7accba030000000000010000000204007ffec9e1233204d9c6dce6812b1539ee96af691ca2e4d9065daa85907d33e5d305007ffec9e1233204d9c6dce6812b1539ee96af691ca2e4d9065daa85907d33e5d30200007ffec9e1233204d9c6dce6812b1539ee96af691ca2e4d9065daa85907d33e5d30203000102030101007ffec9e1233204d9c6dce6812b1539ee96af691ca2e4d9065daa85907d33e5d3
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
         '500':
           description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
           content:
@@ -601,6 +634,10 @@ paths:
           example: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
           required: true
           description: Identifier of the transaction to look up.
+      requestBody:
+        content:
+          application/json: { }
+          application/vnd.iota.serializer-v1: { }
       responses:
         '200':
           description: "Successful operation."
@@ -610,7 +647,14 @@ paths:
                 $ref: '#/components/schemas/MessageResponse'
               examples:
                 default:
-                  $ref: '#/components/examples/get-included-message-of-transaction-example'
+                  $ref: '#/components/examples/get-included-message-of-transaction-example-json'
+            application/vnd.iota.serializer-v1:
+              schema:
+                type: string
+                format: binary
+                description: message in raw binary format
+                example: >-
+                  0204174e3151f6ce2cfb7f00829ac4a96a35caa2078cc20eba99359867cd21aad0d65807bb4ad068e6cdadd103218e4e24ed55b62c985d4f64e97808d9f09180f89c7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695de9e9d780ba7ebeebc38da16cb53b2a8991d38eee94bcdc3f3ef99aa8c345652530100000600000001c9b000b41dc00400010000af7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef00000e6c2998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a79010003a08601000000000000010000a18996d96163405e3c0eb13fa3459a07f68a89e8cf7cc239c89e7192344daa5b0069000000050000000b68656c6c6f20776f726c64550000005370616d6d696e6720646174612e0a436f756e743a203037323935320a54696d657374616d703a20323032312d30322d31315431303a32333a34392b30313a30300a54697073656c656374696f6e3a203934c2b57301000000ee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f40500492a353f96883c472e2686a640e77eda30be8fcc417aa9fc1c15eae854661e0253287be6ea68f649f19ca590de0a6c57fb88635ef0e013310e0be2b8360950350390000000000f0
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -685,7 +729,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-
   '/api/v2/milestones/milestoneId/{milestoneId}':
     get:
       tags:
@@ -735,7 +778,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-
   '/api/v2/milestones/{index}/utxo-changes':
     get:
       tags:
@@ -785,7 +827,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-
 
   /api/v2/peers:
     get:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -151,8 +151,9 @@ paths:
         build the block. On success, the block will be stored in the Tangle.
         This endpoint will return the identifier of the built block. *The
         node will try to auto-fill the following fields in case they are
-        missing: `protocolVersion`, `parents`, `nonce`.
+        missing: `parents`, `nonce`.
         If `payload` is missing, the block will be built without a payload.
+        `protocolVersion` is always required!
       requestBody:
         content:
           application/json:
@@ -1342,6 +1343,7 @@ components:
 
     post-tagged-data-block-request-example-minimal:
       value:
+        protocolVersion: 2
         payload:
           type: 5
           tag: "0x68656c6c6f20776f726c64"
@@ -1349,6 +1351,7 @@ components:
 
     post-transaction-block-request-example-minimal:
       value:
+        protocolVersion: 2
         payload:
           type: 6
           essence:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1471,6 +1471,8 @@ components:
           type: 1
           index: 16241
           timestamp: 1617959712
+          protocolVersion: 2
+          previousMilestoneId: "0xa6db9d0b3ecb274d90c21e9dde04012b2d13ad8aa0b90e82e7d3b626be67119d"
           parents:
             - "0x23d388b13f64c2e24788d61891079c74daf6d036b768d75ad38e473c9d4da83b"
             - "0x242974b25cab6f8378fe718ea729fa65492f03df4ce74b631899589242fa12b7"
@@ -1478,13 +1480,16 @@ components:
             - "0x438a14a651b8872896b4e57c92041e8962ca7d78cc38c774534020feefeff31a"
             - "0x73c90398fb548a4410b49264e182e58a91baeecaa949cbfc1d01a9066cbd9935"
             - "0xb9adfdc1effd3242b5c1d7b6df43d4b53e58943e820ced89c7dd39b8b52fcef0"
-          inclusionMerkleProof: "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
-          nextPoWScore: 0
-          nextPoWScoreMilestoneIndex: 0
+          inclusionMerkleRoot: "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+          appliedMerkleRoot: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
           publicKeys:
             - "0x7205c145525cee64f1c9363696811d239919d830ad964b4e29359e6475848f5a"
             - "0xe468e82df33d10dea3bd0eadcd7867946a674d207c39f5af4cc44365d268a7e6"
-          receipt:
+          options:
+            - type: 1
+              targetMilestoneIndex: 16245
+              protocolVersion: 2
+              params: "0x174612e0a436f756e743a203037323935320a54696d657374616d703a203132372e3030302e3030302e303030"
           signatures:
             - "0xa642e96f71094f8523790131481e0fbfdc8265caa8e4b08793628b286065c317a5595d56edb5e918b24d4ee749768a2b5ae6010e751bf31f0d8145a390b82c00"
             - "0x4bdfa2684bed01ce3a9a630b0688e868c290b8524c679daa79cb9d9f0f2aa5c57cf00a0fc694d1fed3696053ffa9bba6154ccb1564532cd49f807ba77de9a70c"
@@ -1645,8 +1650,8 @@ components:
         appliedMerkleRoot: "0xee26ac07834c603c22130fced361ca58552b0dbfc63e4b73ba24b3b59d9f4050"
         options:
          - type: 1
-           targetMilestoneIndex: 2000
-           protocolVersion: 13
+           targetMilestoneIndex: 15468
+           protocolVersion: 3
            params: "0x27d0ca22753f76ef32d1e9e8fcc417aa9fc1c15eae854661e0253287be6ea68f649493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d6"
         metadata: "0xd6ac43e9ca750"
         signatures:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -3104,7 +3104,7 @@ components:
         metadata:
           description: Metadata of the output.
           allOf:
-            - $ref: '#components/schemas/OutputMetadataResponse'
+            - $ref: '#/components/schemas/OutputMetadataResponse'
         output:
           description: The actual output content.
           anyOf:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2011,7 +2011,7 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         aliasId:
           type: string
-          description: Unique identifier of the alias, which is the BLAKE2b-160 hash of the Output ID that created it.
+          description: Unique identifier of the alias, which is the BLAKE2b-256 hash of the Output ID that created it.
             Alias Address = Alias Address Type || Alias ID. Hex-encoded data with 0x prefix.
         stateIndex:
           type: integer
@@ -2123,7 +2123,7 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         nftId:
           type: string
-          description: Unique identifier of the NFT, which is the BLAKE2b-160 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID. Hex-encoded data with 0x prefix.
+          description: Unique identifier of the NFT, which is the BLAKE2b-256 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID. Hex-encoded data with 0x prefix.
         unlockConditions:
           type: array
           description: Unlock condtions that define how the output an be unlocked in a transaction.
@@ -2190,7 +2190,7 @@ components:
           description: Set to value 8 to denote an Alias Address.
         aliasId:
           type: string
-          description: The hex-encoded, 0x prefixed BLAKE2b-160 hash of the outputId that created the alias.
+          description: The hex-encoded, 0x prefixed BLAKE2b-256 hash of the outputId that created the alias.
       required:
         - type
         - aliasId
@@ -2203,7 +2203,7 @@ components:
           description: Set to value 16 to denote an NFT Address.
         nftId:
           type: string
-          description: The hex-encoded, 0x prefixed BLAKE2b-160 hash of the outputId that created the NFT.
+          description: The hex-encoded, 0x prefixed BLAKE2b-256 hash of the outputId that created the NFT.
       required:
         - type
         - nftId

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -3043,7 +3043,23 @@ components:
           description: If `included`, the message contains a transaction that has been included in the ledger. If `conflicitng`, the message contains a transaction that has not been included in the ledger because it conflicts with another transaction. If the message does not contain a transaction, `ledgerInclusionState` is set to `noTransaction`.
         conflictReason:
           type: integer
-          description: "Defines the reason why a message is marked as conflicting. Value `1` denotes that the referenced UTXO was already spent. Value `2`denotes that the referenced UTXO was already spent while confirming this milestone. Value `3` denotes that the referenced UTXO cannot be found. Value `4` denotes that the sum of the inputs and output values does not match. Value `5` denotes that the unlock block signature is invalid. Value `6` denotes that the input or output type used is unsupported. Value `7` denotes that the used address type is unsupported. Value `8` denotes that the dust allowance for the address is invalid. Value `9` denotes that the semantic validation failed."
+          enum: [1,2,3,4,5,6,7,8,9,10,11,12,255]
+          description: >
+            Values:
+              * `1` - denotes that the referenced UTXO was already spent.
+              * `2` - denotes that the referenced UTXO was already spent while confirming this milestone.
+              * `3` - denotes that the referenced UTXO cannot be found.
+              * `4` - denotes that the sum of the inputs and output values does not match.
+              * `5` - denotes that the unlock block signature is invalid.
+              * `6` - denotes that the configured timelock is not yet expired.
+              * `7` - denotes that the given native tokens are invalid.
+              * `8` - denotes that the return amount in a transaction is not fulfilled by the output side.
+              * `9` - denotes that the input unlock is invalid.
+              * `10` - denotes that the inputs commitment is invalid.
+              * `11` - denotes that an output contains a Sender with an ident (address) which is not unlocked.
+              * `12` - denotes that the chain state transition is invalid.
+              * `255` - denotes that the semantic validation failed.
+
         shouldPromote:
           type: boolean
           description: Tells if the message should be promoted to get more likely picked up by the Coordinator.

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1360,7 +1360,7 @@ components:
                       type: 0
                       pubKeyHash: "0xd49931814e6bfbb8e221f1b2936e206e5a6b6abeb9c070f8603814c525c9abe3"
             payload:
-          unlockBlocks:
+          unlocks:
             - type: 0
               signature:
                 type: 0
@@ -1405,7 +1405,7 @@ components:
                       type: 0
                       pubKeyHash: "0xd49931814e6bfbb8e221f1b2936e206e5a6b6abeb9c070f8603814c525c9abe3"
             payload:
-          unlockBlocks:
+          unlocks:
             - type: 0
               signature:
                 type: 0
@@ -1459,7 +1459,7 @@ components:
                       type: 0
                       pubKeyHash: "0xd49931814e6bfbb8e221f1b2936e206e5a6b6abeb9c070f8603814c525c9abe3"
             payload:
-          unlockBlocks:
+          unlocks:
             - type: 0
               signature:
                 type: 0
@@ -1652,7 +1652,7 @@ components:
               type: 2
               index: "0x454f59"
               data: ""
-          unlockBlocks:
+          unlocks:
             - type: 0
               signature:
                 type: 0
@@ -1891,18 +1891,18 @@ components:
           type: object
           oneOf:
             - $ref: '#/components/schemas/TransactionEssence'
-        unlockBlocks:
+        unlocks:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/SignatureUnlockBlock'
-              - $ref: '#/components/schemas/ReferenceUnlockBlock'
-              - $ref: '#/components/schemas/AliasUnlockBlock'
-              - $ref: '#/components/schemas/NFTUnlockBlock'
+              - $ref: '#/components/schemas/SignatureUnlock'
+              - $ref: '#/components/schemas/ReferenceUnlock'
+              - $ref: '#/components/schemas/AliasUnlock'
+              - $ref: '#/components/schemas/NFTUnlock'
       required:
         - type
         - essence
-        - unlockBlocks
+        - unlocks
 
     TransactionEssence:
       description: Describes the essence data making up a transaction by defining its inputs and outputs and an optional payload.
@@ -2398,12 +2398,12 @@ components:
         - meltedTokens
         - maxSupply
 
-    SignatureUnlockBlock:
-      description: Defines an unlock block containing signature(s) unlocking input(s).
+    SignatureUnlock:
+      description: Defines an unlock containing signature(s) unlocking input(s).
       properties:
         type:
           type: integer
-          description: Denotes a Signature Unlock Block.
+          description: Denotes a Signature Unlock.
         signature:
           type: object
           oneOf:
@@ -2429,41 +2429,41 @@ components:
         - publicKey
         - signature
 
-    ReferenceUnlockBlock:
-      description: References a previous unlock block in order to substitute the duplication of the same unlock block data for inputs which unlock through the same data.
+    ReferenceUnlock:
+      description: References a previous unlock in order to substitute the duplication of the same unlock data for inputs which unlock through the same data.
       properties:
         type:
           type: integer
-          description: Set to value 1 to denote a Reference Unlock Block.
+          description: Set to value 1 to denote a Reference Unlock.
         reference:
           type: integer
-          description: Represents the index of a previous unlock block.
+          description: Represents the index of a previous unlock.
       required:
         - type
         - reference
 
-    AliasUnlockBlock:
-      description: References a previous unlock block that unlocks an Alias Output.
+    AliasUnlock:
+      description: References a previous unlock that unlocks an Alias Output.
       properties:
         type:
           type: integer
-          description: Set to value 2 to denote an Alias Unlock Block.
+          description: Set to value 2 to denote an Alias Unlock.
         reference:
           type: integer
-          description: Represents the index of a previous unlock block.
+          description: Represents the index of a previous unlock.
       required:
         - type
         - reference
 
-    NFTUnlockBlock:
-      description: References a previous unlock block that unlocks an NFT Output.
+    NFTUnlock:
+      description: References a previous unlock that unlocks an NFT Output.
       properties:
         type:
           type: integer
-          description: Set to value 3 to denote an NFT Unlock Block.
+          description: Set to value 3 to denote an NFT Unlock.
         reference:
           type: integer
-          description: Represents the index of a previous unlock block.
+          description: Represents the index of a previous unlock.
       required:
         - type
         - reference

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -431,13 +431,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-
-  '/api/v2/outputs/{outputId}':
+  '/api/v2/outputs/{outputId}/metadata':
     get:
       tags:
         - UTXO
-      summary: Find an output by its identifier.
-      description: Find an output by its identifier.
+      summary: Returns metadata about an output by its identifier.
+      description: Returns metadata about an output by its identifier.
       parameters:
         - in: path
           name: outputId
@@ -454,12 +453,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OutputResponse'
+                $ref: '#/components/schemas/OutputMetadataResponse'
               examples:
                 unspent:
-                  $ref: '#/components/examples/get-outputs-by-id-response-unspent-example'
+                  $ref: '#/components/examples/get-output-metadata-by-id-response-unspent-example'
                 spent:
-                  $ref: '#/components/examples/get-outputs-by-id-response-spent-example'
+                  $ref: '#/components/examples/get-output-metadata-by-id-response-spent-example'
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -526,7 +525,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-
   '/api/v2/receipts/{migratedAt}':
     get:
       tags:
@@ -576,7 +574,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceUnavailableResponse'
-
 
   '/api/v2/treasury':
     get:
@@ -1318,6 +1315,29 @@ components:
               address:
                 type: 0
                 pubKeyHash: "0x8eaf87ac1f52eb05f2c7c0c15502df990a228838dc37bd18de9503d69afd257d"
+
+    get-output-metadata-by-id-response-unspent-example:
+      value:
+        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+        transactionId: "0x1ee46e19f4219ee65afc10227d0ca22753f76ef32d1e922e5cbe3fbc9b5a5298"
+        outputIndex: 1
+        isSpent: false
+        milestoneIndexBooked: 1234567
+        milestoneTimestampBooked: 1643207146
+        ledgerIndex: 946704
+
+    get-output-metadata-by-id-response-spent-example:
+      value:
+        messageId: "0x9cd745ef6800c8e8c80b09174ee4b250b3c43dfa62d7c6a4e61f848febf731a0"
+        transactionId: "0xfa0de75d225cca2799395e5fc340702fc7eac821d2bdd79911126f131ae097a2"
+        outputIndex: 1
+        isSpent: true
+        milestoneIndexSpent: 1234570
+        milestoneTimestampSpent: 1643207176
+        transactionIdSpent: "0xaf7579fb57746219561072c2cc0e4d0fbb8d493d075bd21bf25ae81a450c11ef"
+        milestoneIndexBooked: 1234567
+        milestoneTimestampBooked: 1643207146
+        ledgerIndex: 946704
 
     get-receipts-response-example:
       value:
@@ -2777,6 +2797,51 @@ components:
         - milestoneIndexBooked
         - milestoneTimestampBooked
         - output
+        - ledgerIndex
+
+    OutputMetadataResponse:
+      description: Returns metadata about an output.
+      properties:
+        messageId:
+          type: string
+          description: The message identifier that references the output. Hex-encoded with 0x prefix.
+        transactionId:
+          type: string
+          description: The identifier of the transaction. Hex-encoded with 0x prefix.
+        outputIndex:
+          type: integer
+          description: The index of the output.
+        isSpent:
+          type: boolean
+          description: Tells if the output is spent or not.
+        milestoneIndexSpent:
+          type: integer
+          description: The milestone index at which this output was spent.
+          nullable: true
+        milestoneTimestampSpent:
+          type: integer
+          description: The milestone timestamp this output was spent.
+          nullable: true
+        transactionIdSpent:
+          type: string
+          description: The transaction this output was spent with. Hex-encoded with 0x prefix.
+          nullable: true
+        milestoneIndexBooked:
+          type: integer
+          description: The milestone index at which the output was booked.
+        milestoneTimestampBooked:
+          type: integer
+          description: The milestone unix timestamp at which the output was booked.
+        ledgerIndex:
+          type: integer
+          description: The current ledger index for which the request was made.
+      required:
+        - messageId
+        - transactionId
+        - outputIndex
+        - isSpent
+        - milestoneIndexBooked
+        - milestoneTimestampBooked
         - ledgerIndex
 
     ReceiptsResponse:

--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1546,8 +1546,8 @@ components:
       value:
         type: 7
         index: 15465
-        messageId: "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         timestamp: 1602227215
+        lastMilestoneId: "0x7ad3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
         parentMessageIds:
          - "0x7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006"
          - "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
@@ -2356,13 +2356,16 @@ components:
       properties:
         type:
           type: integer
-          description: Set to value 1 to denote a Milestone Payload.
+          description: Set to value 7 to denote a Milestone Payload.
         index:
           type: integer
           description: The index of the milestone.
         timestamp:
           type: integer
           description: The Unix timestamp at which the milestone was issued. The unix timestamp is specified in seconds.
+        lastMilestoneId:
+          type: string
+          description: The Milestone ID of the milestone with Index Number - 1.
         parentMessageIds:
           description: The identifiers of the messages this milestone references. Hex-encoded values with 0x prefix.
           type: array
@@ -2393,6 +2396,7 @@ components:
         - type
         - index
         - timestamp
+        - lastMilestoneId
         - parentMessageIds
         - confirmedMerkleRoot
         - appliedMerkleRoot

--- a/tips/TIP-0025/tip-0025.md
+++ b/tips/TIP-0025/tip-0025.md
@@ -3,7 +3,7 @@ tip: 25
 title: Core REST API
 description: Node Core REST API routes and objects in OpenAPI Specification
 author: Samuel Rufinatscha (@rufsam) <samuel.rufinatscha@iota.org>, Levente Pap (@lzpap) <levente.pap@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/26, https://github.com/iotaledger/tips/discussions/53
+discussions-to: https://github.com/iotaledger/tips/pull/27, https://github.com/iotaledger/tips/discussions/53, https://github.com/iotaledger/tips/pull/57
 status: Draft
 type: Standards
 layer: Interface
@@ -19,7 +19,7 @@ This document proposes the core REST API for nodes supporting the IOTA protocol.
 
 The API is described using the OpenAPI Specification:
 
-[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/stardust-api/tips/TIP-0025/core-rest-api.yaml)
+[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml)
 
 # Copyright
 


### PR DESCRIPTION
Core API specification update for Stardust, mostly based on [TIP-13](https://github.com/iotaledger/tips/blob/main/tips/TIP-0013/tip-0013.md).

Important updates:
 - Renaming _messages_ to _blocks_
 - Removal of block lookup by indexation tag. Should be done via a block indexer node plugin that exposes its own routes.
- Removal of address/balance lookups under the utxo routes. Outputs can only be fetched by `OutputID` from the core API. An indexer API described in #53 will expose new routes to fetch outputs based on parameters. 
- Added outputs and unlocks from [TIP-18](#38).
- Added `milestoneIndexBooked` and `milestoneTimestampBooked` to `OutputResponse`.

[Rendered version](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/stardust-api/tips/TIP-0025/core-rest-api.yaml)
 