### PR TITLE
TIP-26 UTXO Indexer REST API

### DIFF
--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -747,7 +747,7 @@ components:
               type: array
               description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
               items:
-                - type: string
+                type: string
           required:
             - ledgerIndex
             - limit

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -37,23 +37,85 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Bech32-encoded address that should be searched for.
         - in: query
-          name: requiresDustReturn
+          name: hasDustReturnCondition
           schema:
             type: boolean
           example: true
           description: Filters outputs based on the presence of dust return unlock condition.
         - in: query
-          name: timelock-params
+          name: dustReturnAddress
           schema:
             type: string
-          example: TODO
-          description: TODO - update placeholder when indexer is ready
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on the presence of a specific return address in the dust deposit return
+            unlock condition.
         - in: query
-          name: expiration-params
+          name: hasTimelockCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of timelock unlock condition.
+        - in: query
+          name: timelockedBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that are timelocked before a certain Unix timestamp.
+        - in: query
+          name: timelockedAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that are timelocked after a certain Unix timestamp.
+        - in: query
+          name: timelockedBeforeMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that are timelocked before a certain milestone index.
+        - in: query
+          name: timelockedAfterMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that are timelocked after a certain milestone index.
+        - in: query
+          name: hasExpirationCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of expiration unlock condition.
+        - in: query
+          name: expiresBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that expire before a certain Unix timestamp.
+        - in: query
+          name: expiresAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that expire after a certain Unix timestamp.
+        - in: query
+          name: expiresBeforeMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that expire before a certain milestone index.
+        - in: query
+          name: expiresAfterMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that expire after a certain milestone index.
+        - in: query
+          name: expirationReturnAddress
           schema:
             type: string
-          example: TODO
-          description: TODO - update placeholder when indexer is ready
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on the presence of a specific return address in the expiration unlock
+            condition.
         - in: query
           name: sender
           schema:
@@ -66,6 +128,18 @@ paths:
             type: string
           example: 4ec7f23
           description: Filters outputs based on matching Tag Block.
+        - in: query
+          name: createdBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created before a certain Unix timestamp.
+        - in: query
+          name: createdAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created after a certain Unix timestamp.
         - in: query
           name: offset
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -35,7 +35,7 @@ paths:
           schema:
             type: string
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Bech32-encoded address that should be searched for.
+          description: The Bech32-encoded address that should be searched for in the Address Unlock Condition of outputs.
         - in: query
           name: hasNativeTokens
           schema:
@@ -497,7 +497,7 @@ paths:
           schema:
             type: string
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Bech32-encoded address that should be searched for.
+          description: The Bech32-encoded address that should be searched for in the Address Unlock Condition of outputs.
         - in: query
           name: issuer
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -15,7 +15,7 @@ servers:
   - url: 'http://127.0.0.1:14265'
 tags:
   - name: outputs
-    description: Query Extended Outputs.
+    description: Query Basic Outputs.
   - name: aliases
     description: Query Alias Outputs.
   - name: foundries
@@ -27,8 +27,8 @@ paths:
     get:
       tags:
         - outputs
-      summary: Returns extended outputs filtered based on parameters.
-      description: Returns extended outputs filtered based on parameters.
+      summary: Returns basic outputs filtered based on parameters.
+      description: Returns basic outputs filtered based on parameters.
       parameters:
         - in: query
           name: address

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -211,6 +211,18 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Filters outputs based on bech32-encoded sender address.
         - in: query
+          name: createdBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created before a certain Unix timestamp.
+        - in: query
+          name: createdAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created after a certain Unix timestamp.
+        - in: query
           name: offset
           schema:
             type: string
@@ -312,6 +324,18 @@ paths:
             type: string
           example: iota1ppk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn
           description: Filter foundry outputs based on bech32-encoded address of the controlling alias.
+        - in: query
+          name: createdBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created before a certain Unix timestamp.
+        - in: query
+          name: createdAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created after a certain Unix timestamp.
         - in: query
           name: offset
           schema:
@@ -415,41 +439,109 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Bech32-encoded address that should be searched for.
         - in: query
-          name: requiresDustReturn
+          name: hasDustReturnCondition
           schema:
             type: boolean
           example: true
           description: Filters outputs based on the presence of dust return unlock condition.
         - in: query
-          name: timelock-params
+          name: dustReturnAddress
           schema:
             type: string
-          example: TODO
-          description: TODO - update placeholder when indexer is ready
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on the presence of a specific return address in the dust deposit return
+            unlock condition.
         - in: query
-          name: expiration-params
+          name: hasTimelockCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of timelock unlock condition.
+        - in: query
+          name: timelockedBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that are timelocked before a certain Unix timestamp.
+        - in: query
+          name: timelockedAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that are timelocked after a certain Unix timestamp.
+        - in: query
+          name: timelockedBeforeMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that are timelocked before a certain milestone index.
+        - in: query
+          name: timelockedAfterMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that are timelocked after a certain milestone index.
+        - in: query
+          name: hasExpirationCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of expiration unlock condition.
+        - in: query
+          name: expiresBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that expire before a certain Unix timestamp.
+        - in: query
+          name: expiresAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that expire after a certain Unix timestamp.
+        - in: query
+          name: expiresBeforeMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that expire before a certain milestone index.
+        - in: query
+          name: expiresAfterMilestone
+          schema:
+            type: integer
+          example: 1000
+          description: Return outputs that expire after a certain milestone index.
+        - in: query
+          name: expirationReturnAddress
           schema:
             type: string
-          example: TODO
-          description: TODO - update placeholder when indexer is ready
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on the presence of a specific return address in the expiration unlock
+            condition.
         - in: query
           name: sender
           schema:
             type: string
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Filters outputs based on the presence of validated Sender (bech32-encoded).
-        - in: query
-          name: issuer
-          schema:
-            type: string
-          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Filters outputs based on the presence of validated Issuer (bech32-encoded).
+          description: Filters outputs based on the presence of validated Sender (bech32 encoded).
         - in: query
           name: tag
           schema:
             type: string
           example: 4ec7f23
           description: Filters outputs based on matching Tag Block.
+        - in: query
+          name: createdBefore
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created before a certain Unix timestamp.
+        - in: query
+          name: createdAfter
+          schema:
+            type: integer
+          example: 1643383242
+          description: Return outputs that were created after a certain Unix timestamp.
         - in: query
           name: offset
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -14,7 +14,7 @@ externalDocs:
 servers:
   - url: 'http://127.0.0.1:14265'
 tags:
-  - name: outputs
+  - name: basic outputs
     description: Query Basic Outputs.
   - name: aliases
     description: Query Alias Outputs.

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -164,6 +164,7 @@ paths:
             type: integer
           example: 10
           description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
+            The parameter is ignored when pageSize is defined via the cursor parameter.
         - in: query
           name: cursor
           schema:
@@ -273,6 +274,7 @@ paths:
             type: integer
           example: 10
           description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
+            The parameter is ignored when pageSize is defined via the cursor parameter.
         - in: query
           name: cursor
           schema:
@@ -414,6 +416,7 @@ paths:
             type: integer
           example: 10
           description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
+            The parameter is ignored when pageSize is defined via the cursor parameter.
         - in: query
           name: cursor
           schema:
@@ -647,6 +650,7 @@ paths:
             type: integer
           example: 10
           description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
+            The parameter is ignored when pageSize is defined via the cursor parameter.
         - in: query
           name: cursor
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -160,6 +160,9 @@ paths:
                 No matching outputIds found:
                   $ref: >-
                     #/components/examples/get-outputs-empty-response-example
+                Paging - more items found than it can fit on single page:
+                  $ref: >-
+                    #/components/examples/get-outputs-pagesize2-response-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -242,6 +245,9 @@ paths:
                 No matching outputIds found:
                   $ref: >-
                     #/components/examples/get-outputs-empty-response-example
+                Paging - more items found than it can fit on single page:
+                  $ref: >-
+                    #/components/examples/get-outputs-pagesize2-response-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -356,6 +362,9 @@ paths:
                 No matching outputIds found:
                   $ref: >-
                     #/components/examples/get-outputs-empty-response-example
+                Paging - more items found than it can fit on single page:
+                  $ref: >-
+                    #/components/examples/get-outputs-pagesize2-response-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -562,6 +571,9 @@ paths:
                 No matching outputIds found:
                   $ref: >-
                     #/components/examples/get-outputs-empty-response-example
+                Paging - more items found than it can fit on single page:
+                  $ref: >-
+                    #/components/examples/get-outputs-pagesize2-response-example
         '400':
           description: "Unsuccessful operation: indicates that the provided data is invalid."
           content:
@@ -634,30 +646,28 @@ components:
   examples:
     get-outputs-response-three-example:
       value:
-        data:
-          ledgerIndex: 101
-          limit: 1000
-          count: 3
-          outputIds:
-            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
-            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
-            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+        ledgerIndex: 101
+        items:
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
     get-outputs-response-single-example:
       value:
-        data:
-          ledgerIndex: 101
-          limit: 1000
-          count: 1
-          outputIds:
-            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+        ledgerIndex: 101
+        items:
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
     get-outputs-empty-response-example:
       value:
-        data:
-          ledgerIndex: 101
-          limit: 1000
-          count: 0
-          outputIds:
-            -
+        ledgerIndex: 101
+        items:
+          -
+    get-outputs-pagesize2-response-example:
+      value:
+        ledgerIndex: 101
+        cursor: 61fa44a14d35ce14b9d0e7ee6ac9af70c0af156be269f69348be6d6f83c80a3a8a44ce440000.2
+        items:
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
 
 
   schemas:
@@ -727,31 +737,18 @@ components:
     OutputsResponse:
       description: Returns a list of OutputIds.
       properties:
-        data:
-          type: object
-          properties:
-            ledgerIndex:
-              type: integer
-              description: The current ledger index for which the request was made.
-            limit:
-              type: integer
-              description: The maximum count of results that are returned by the node.
-            offset:
-              type: integer
-              description: The offset to use for getting the next results.
-              nullable: true
-            count:
-              type: integer
-              description: The actual count of results that are returned.
-            outputIds:
-              type: array
-              description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
-              items:
-                type: string
-          required:
-            - ledgerIndex
-            - limit
-            - count
-            - outputIds
+        ledgerIndex:
+          type: integer
+          description: The current ledger index for which the request was made.
+        cursor:
+          type: integer
+          description: The cursor to use for getting the next page of results.
+          nullable: true
+        items:
+          type: array
+          description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
+          items:
+            type: string
       required:
-        - data
+          - ledgerIndex
+          - items

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -34,8 +34,8 @@ paths:
           name: address
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Hex-encoded address that should be searched for.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Bech32-encoded address that should be searched for.
         - in: query
           name: requiresDustReturn
           schema:
@@ -58,8 +58,8 @@ paths:
           name: sender
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filters outputs based on the presence of validated Sender.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on the presence of validated Sender (bech32 encoded).
         - in: query
           name: tag
           schema:
@@ -116,26 +116,26 @@ paths:
           name: stateController
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filter outputs based on hex-encoded state controller address.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on bech32-encoded state controller address.
         - in: query
           name: governor
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filter outputs based on hex-encoded governor (governance controller) address.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filter outputs based on bech32-encoded governor (governance controller) address.
         - in: query
           name: issuer
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filters outputs based on hex-encoded issuer address.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on bech32-encoded issuer address.
         - in: query
           name: sender
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filters outputs based on hex-encoded sender address.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on bech32-encoded sender address.
         - in: query
           name: offset
           schema:
@@ -188,6 +188,7 @@ paths:
             type: string
           example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
           description: Unique identifier of the alias.
+          required: true
       responses:
         '200':
           description: "Successful operation."
@@ -235,8 +236,8 @@ paths:
           name: address
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filter foundry outputs based on hex-encoded address of the controlling alias.
+          example: iota1ppk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn
+          description: Filter foundry outputs based on bech32-encoded address of the controlling alias.
         - in: query
           name: offset
           schema:
@@ -289,6 +290,7 @@ paths:
             type: string
           example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
           description: Unique identifier of the foundry.
+          required: true
       responses:
         '200':
           description: "Successful operation."
@@ -336,8 +338,8 @@ paths:
           name: address
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Hex-encoded address that should be searched for.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Bech32-encoded address that should be searched for.
         - in: query
           name: requiresDustReturn
           schema:
@@ -426,6 +428,7 @@ paths:
             type: string
           example: 4d09c5ef6a61766beb0b5655fdf0b379bac8a813
           description: Unique identifier of the nft.
+          required: true
       responses:
         '200':
           description: "Successful operation."

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -151,7 +151,7 @@ paths:
           schema:
             type: string
           example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
-          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
+          description: Starts the search from the cursor (confirmationMS+outputId.pageSize).
       responses:
         '200':
           description: "Successful operation."
@@ -242,7 +242,7 @@ paths:
           schema:
             type: string
           example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
-          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
+          description: Starts the search from the cursor (confirmationMS+outputId.pageSize).
       responses:
         '200':
           description: "Successful operation."
@@ -365,7 +365,7 @@ paths:
           schema:
             type: string
           example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
-          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
+          description: Starts the search from the cursor (confirmationMS+outputId.pageSize).
       responses:
         '200':
           description: "Successful operation."
@@ -580,7 +580,7 @@ paths:
           schema:
             type: string
           example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
-          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
+          description: Starts the search from the cursor (confirmationMS+outputId.pageSize).
       responses:
         '200':
           description: "Successful operation."

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -86,18 +86,6 @@ paths:
           example: 1643383242
           description: Return outputs that are timelocked after a certain Unix timestamp.
         - in: query
-          name: timelockedBeforeMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that are timelocked before a certain milestone index.
-        - in: query
-          name: timelockedAfterMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that are timelocked after a certain milestone index.
-        - in: query
           name: hasExpirationCondition
           schema:
             type: boolean
@@ -115,18 +103,6 @@ paths:
             type: integer
           example: 1643383242
           description: Return outputs that expire after a certain Unix timestamp.
-        - in: query
-          name: expiresBeforeMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that expire before a certain milestone index.
-        - in: query
-          name: expiresAfterMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that expire after a certain milestone index.
         - in: query
           name: expirationReturnAddress
           schema:
@@ -572,18 +548,6 @@ paths:
           example: 1643383242
           description: Return outputs that are timelocked after a certain Unix timestamp.
         - in: query
-          name: timelockedBeforeMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that are timelocked before a certain milestone index.
-        - in: query
-          name: timelockedAfterMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that are timelocked after a certain milestone index.
-        - in: query
           name: hasExpirationCondition
           schema:
             type: boolean
@@ -601,18 +565,6 @@ paths:
             type: integer
           example: 1643383242
           description: Return outputs that expire after a certain Unix timestamp.
-        - in: query
-          name: expiresBeforeMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that expire before a certain milestone index.
-        - in: query
-          name: expiresAfterMilestone
-          schema:
-            type: integer
-          example: 1000
-          description: Return outputs that expire after a certain milestone index.
         - in: query
           name: expirationReturnAddress
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -362,14 +362,14 @@ paths:
           name: sender
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filters outputs based on the presence of validated Sender.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on the presence of validated Sender (bech32-encoded).
         - in: query
           name: issuer
           schema:
             type: string
-          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
-          description: Filters outputs based on the presence of validated Issuer.
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on the presence of validated Issuer (bech32-encoded).
         - in: query
           name: tag
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -37,17 +37,35 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Bech32-encoded address that should be searched for.
         - in: query
-          name: hasDustReturnCondition
+          name: hasNativeTokens
           schema:
             type: boolean
           example: true
-          description: Filters outputs based on the presence of dust return unlock condition.
+          description: Filters outputs based on the presence of native tokens.
         - in: query
-          name: dustReturnAddress
+          name: minNativeTokenCount
+          schema:
+            type: integer
+          example: 2
+          description: Filters outputs that have at least a certain number of distinct native tokens.
+        - in: query
+          name: maxNativeTokenCount
+          schema:
+            type: integer
+          example: 5
+          description: Filters outputs that have at most a certain number of distinct native tokens.
+        - in: query
+          name: hasStorageReturnCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of storage deposit return unlock condition.
+        - in: query
+          name: storageReturnAddress
           schema:
             type: string
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Filter outputs based on the presence of a specific return address in the dust deposit return
+          description: Filter outputs based on the presence of a specific return address in the storage deposit return
             unlock condition.
         - in: query
           name: hasTimelockCondition
@@ -220,6 +238,24 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Filters outputs based on bech32-encoded sender address.
         - in: query
+          name: hasNativeTokens
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of native tokens.
+        - in: query
+          name: minNativeTokenCount
+          schema:
+            type: integer
+          example: 2
+          description: Filters outputs that have at least a certain number of distinct native tokens.
+        - in: query
+          name: maxNativeTokenCount
+          schema:
+            type: integer
+          example: 5
+          description: Filters outputs that have at most a certain number of distinct native tokens.
+        - in: query
           name: createdBefore
           schema:
             type: integer
@@ -342,6 +378,24 @@ paths:
             type: string
           example: iota1ppk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn
           description: Filter foundry outputs based on bech32-encoded address of the controlling alias.
+        - in: query
+          name: hasNativeTokens
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of native tokens.
+        - in: query
+          name: minNativeTokenCount
+          schema:
+            type: integer
+          example: 2
+          description: Filters outputs that have at least a certain number of distinct native tokens.
+        - in: query
+          name: maxNativeTokenCount
+          schema:
+            type: integer
+          example: 5
+          description: Filters outputs that have at most a certain number of distinct native tokens.
         - in: query
           name: createdBefore
           schema:
@@ -466,17 +520,35 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Bech32-encoded address that should be searched for.
         - in: query
-          name: hasDustReturnCondition
+          name: hasNativeTokens
           schema:
             type: boolean
           example: true
-          description: Filters outputs based on the presence of dust return unlock condition.
+          description: Filters outputs based on the presence of native tokens.
         - in: query
-          name: dustReturnAddress
+          name: minNativeTokenCount
+          schema:
+            type: integer
+          example: 2
+          description: Filters outputs that have at least a certain number of distinct native tokens.
+        - in: query
+          name: maxNativeTokenCount
+          schema:
+            type: integer
+          example: 5
+          description: Filters outputs that have at most a certain number of distinct native tokens.
+        - in: query
+          name: hasStorageReturnCondition
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of storage deposit return unlock condition.
+        - in: query
+          name: storageReturnAddress
           schema:
             type: string
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Filter outputs based on the presence of a specific return address in the dust deposit return
+          description: Filter outputs based on the presence of a specific return address in the storage deposit return
             unlock condition.
         - in: query
           name: hasTimelockCondition

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -746,6 +746,8 @@ components:
             outputIds:
               type: array
               description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
+              items:
+                - type: string
           required:
             - ledgerIndex
             - limit

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -328,7 +328,7 @@ paths:
           name: aliasId
           schema:
             type: string
-          example: "0xb098c0ee963575a8d505c299a99ce9c32cd4ecb3"
+          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
           description: Unique identifier of the alias.
           required: true
       responses:
@@ -470,7 +470,7 @@ paths:
           name: foundryId
           schema:
             type: string
-          example: "0xb098c0ee963575a8d505c299a99ce9c32cd4ecb3"
+          example: "0x081505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d60100000000"
           description: Unique identifier of the foundry.
           required: true
       responses:
@@ -704,7 +704,7 @@ paths:
           name: nftId
           schema:
             type: string
-          example: "0x4d09c5ef6a61766beb0b5655fdf0b379bac8a813"
+          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
           description: Unique identifier of the nft.
           required: true
       responses:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -145,7 +145,7 @@ paths:
           schema:
             type: string
           example: "0x4ec7f23"
-          description: Filters outputs based on matching Tag Block.
+          description: Filters outputs based on matching Tag Feature.
         - in: query
           name: createdBefore
           schema:
@@ -631,7 +631,7 @@ paths:
           schema:
             type: string
           example: "0x4ec7f23"
-          description: Filters outputs based on matching Tag Block.
+          description: Filters outputs based on matching Tag Feature.
         - in: query
           name: createdBefore
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -23,7 +23,7 @@ tags:
   - name: nfts
     description: Query NFT Outputs.
 paths:
-  /api/plugins/indexer/v1/outputs:
+  /api/plugins/indexer/v1/basic-outputs:
     get:
       tags:
         - outputs

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -499,6 +499,18 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Bech32-encoded address that should be searched for.
         - in: query
+          name: issuer
+          schema:
+            type: string
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on bech32-encoded issuer address.
+        - in: query
+          name: sender
+          schema:
+            type: string
+          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
+          description: Filters outputs based on the presence of validated Sender (bech32 encoded).
+        - in: query
           name: hasNativeTokens
           schema:
             type: boolean
@@ -572,12 +584,6 @@ paths:
           example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
           description: Filter outputs based on the presence of a specific return address in the expiration unlock
             condition.
-        - in: query
-          name: sender
-          schema:
-            type: string
-          example: iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx
-          description: Filters outputs based on the presence of validated Sender (bech32 encoded).
         - in: query
           name: tag
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -141,11 +141,11 @@ paths:
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
         - in: query
-          name: offset
+          name: cursor
           schema:
             type: string
-          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
-          description: Starts the search from the offset (outputID).
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
+          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
       responses:
         '200':
           description: "Successful operation."
@@ -226,11 +226,11 @@ paths:
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
         - in: query
-          name: offset
+          name: cursor
           schema:
             type: string
-          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
-          description: Starts the search from the offset (outputID).
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
+          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
       responses:
         '200':
           description: "Successful operation."
@@ -343,11 +343,11 @@ paths:
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
         - in: query
-          name: offset
+          name: cursor
           schema:
             type: string
-          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
-          description: Starts the search from the offset (outputID).
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
+          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
       responses:
         '200':
           description: "Successful operation."
@@ -552,11 +552,11 @@ paths:
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
         - in: query
-          name: offset
+          name: cursor
           schema:
             type: string
-          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
-          description: Starts the search from the offset (outputID).
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200.10
+          description: Starts the search from the cursor (<confirmationMS><outputId>.<pageSize>).
       responses:
         '200':
           description: "Successful operation."

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -1,0 +1,586 @@
+openapi: 3.0.3
+info:
+  title: IOTA UTXO Indexer REST API
+  description: This document specifies the REST API for IOTA UTXO indexers.
+  contact:
+    email: contact@iota.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  version: 1.0.0
+externalDocs:
+  description: Find out more about IOTA
+  url: 'https://iota.org'
+servers:
+  - url: 'http://127.0.0.1:14265'
+tags:
+  - name: outputs
+    description: Query Extended Outputs.
+  - name: aliases
+    description: Query Alias Outputs.
+  - name: foundries
+    description: Query Foundry Outputs.
+  - name: nfts
+    description: Query NFT Outputs.
+paths:
+  /api/plugins/indexer/v1/outputs:
+    get:
+      tags:
+        - outputs
+      summary: Returns extended outputs filtered based on parameters.
+      description: Returns extended outputs filtered based on parameters.
+      parameters:
+        - in: query
+          name: address
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Hex-encoded address that should be searched for.
+        - in: query
+          name: requiresDustReturn
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of dust return unlock condition.
+        - in: query
+          name: timelock-params
+          schema:
+            type: string
+          example: TODO
+          description: TODO - update placeholder when indexer is ready
+        - in: query
+          name: expiration-params
+          schema:
+            type: string
+          example: TODO
+          description: TODO - update placeholder when indexer is ready
+        - in: query
+          name: sender
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filters outputs based on the presence of validated Sender.
+        - in: query
+          name: tag
+          schema:
+            type: string
+          example: 4ec7f23
+          description: Filters outputs based on matching Tag Block.
+        - in: query
+          name: offset
+          schema:
+            type: string
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+          description: Starts the search from the offset (outputID).
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in 3 outputs:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-three-example
+                No matching outputIds found:
+                  $ref: >-
+                    #/components/examples/get-outputs-empty-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/aliases:
+    get:
+      tags:
+        - aliases
+      summary: Returns alias outputs filtered based on parameters.
+      description: Returns alias outputs filtered based on parameters.
+      parameters:
+        - in: query
+          name: stateController
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filter outputs based on hex-encoded state controller address.
+        - in: query
+          name: governor
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filter outputs based on hex-encoded governor (governance controller) address.
+        - in: query
+          name: issuer
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filters outputs based on hex-encoded issuer address.
+        - in: query
+          name: sender
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filters outputs based on hex-encoded sender address.
+        - in: query
+          name: offset
+          schema:
+            type: string
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+          description: Starts the search from the offset (outputID).
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in 3 outputs:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-three-example
+                No matching outputIds found:
+                  $ref: >-
+                    #/components/examples/get-outputs-empty-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/aliases/{aliasId}:
+    get:
+      tags:
+        - aliases
+      summary: Returns the outputId of the current unspent alias output for aliasId.
+      description: Returns the outputId of the current unspent alias output for aliasId.
+      parameters:
+        - in: query
+          name: aliasId
+          schema:
+            type: string
+          example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
+          description: Unique identifier of the alias.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in single output:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-single-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/foundries:
+    get:
+      tags:
+        - foundries
+      summary: Returns foundry outputs filtered based on parameters.
+      description: Returns foundry outputs filtered based on parameters.
+      parameters:
+        - in: query
+          name: address
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filter foundry outputs based on hex-encoded address of the controlling alias.
+        - in: query
+          name: offset
+          schema:
+            type: string
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+          description: Starts the search from the offset (outputID).
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in 3 outputs:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-three-example
+                No matching outputIds found:
+                  $ref: >-
+                    #/components/examples/get-outputs-empty-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/foundries/{foundryId}:
+    get:
+      tags:
+        - foundries
+      summary: Returns the outputId of the current unspent foundry output for foundryId.
+      description: Returns the outputId of the current unspent foundry output for foundryId.
+      parameters:
+        - in: query
+          name: foundryId
+          schema:
+            type: string
+          example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
+          description: Unique identifier of the foundry.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in single outout:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-single-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/nfts:
+    get:
+      tags:
+        - nfts
+      summary: Returns nft outputs filtered based on parameters.
+      description: Returns nft outputs filtered based on parameters.
+      parameters:
+        - in: query
+          name: address
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Hex-encoded address that should be searched for.
+        - in: query
+          name: requiresDustReturn
+          schema:
+            type: boolean
+          example: true
+          description: Filters outputs based on the presence of dust return unlock condition.
+        - in: query
+          name: timelock-params
+          schema:
+            type: string
+          example: TODO
+          description: TODO - update placeholder when indexer is ready
+        - in: query
+          name: expiration-params
+          schema:
+            type: string
+          example: TODO
+          description: TODO - update placeholder when indexer is ready
+        - in: query
+          name: sender
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filters outputs based on the presence of validated Sender.
+        - in: query
+          name: issuer
+          schema:
+            type: string
+          example: f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d
+          description: Filters outputs based on the presence of validated Issuer.
+        - in: query
+          name: tag
+          schema:
+            type: string
+          example: 4ec7f23
+          description: Filters outputs based on matching Tag Block.
+        - in: query
+          name: offset
+          schema:
+            type: string
+          example: 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+          description: Starts the search from the offset (outputID).
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in 3 outputs:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-three-example
+                No matching outputIds found:
+                  $ref: >-
+                    #/components/examples/get-outputs-empty-response-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+
+  /api/plugins/indexer/v1/nfts/{nftId}:
+    get:
+      tags:
+        - nfts
+      summary: Returns the outputId of the current unspent nft output for nftId.
+      description: Returns the outputId of the current nft output for nftId.
+      parameters:
+        - in: query
+          name: nftId
+          schema:
+            type: string
+          example: 4d09c5ef6a61766beb0b5655fdf0b379bac8a813
+          description: Unique identifier of the nft.
+      responses:
+        '200':
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutputsResponse'
+              examples:
+                Query results in single outout:
+                  $ref: >-
+                    #/components/examples/get-outputs-response-single-example
+        '400':
+          description: "Unsuccessful operation: indicates that the provided data is invalid."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: "Unsuccessful operation: indicates that the endpoint is not available for public use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: "Unsuccessful operation: indicates that the requested data was not found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: "Unsuccessful operation: indicates that an unexpected, internal server error happened which prevented the node from fulfilling the request."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorResponse'
+components:
+  examples:
+    get-outputs-response-three-example:
+      value:
+        data:
+          ledgerIndex: 101
+          limit: 1000
+          count: 3
+          outputIds:
+            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
+            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+    get-outputs-response-single-example:
+      value:
+        data:
+          ledgerIndex: 101
+          limit: 1000
+          count: 1
+          outputIds:
+            - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+    get-outputs-empty-response-example:
+      value:
+        data:
+          ledgerIndex: 101
+          limit: 1000
+          count: 0
+          outputIds:
+            -
+
+
+  schemas:
+    ErrorResponse:
+      description: The error format.
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: The application error code.
+            message:
+              type: string
+              description: The error reason.
+          required:
+            - code
+            - message
+      required:
+        - error
+
+    ForbiddenResponse:
+      description: Indicates that this endpoint is not available for public use.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: 403
+          message: not available for public use
+
+    ServiceUnavailableResponse:
+      description: Indicates that the service is unavailable.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: 503
+          message: service unavailable
+
+    BadRequestResponse:
+      description: Indicates that the request was bad.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: 400
+          message: invalid data provided
+
+    NotFoundResponse:
+      description: Indicates that the data was not found.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: 404
+          message: could not find data
+
+    InternalErrorResponse:
+      description: Indicates that the server encountered an unexpected condition, which prevented it from fulfilling the request by the client.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: 500
+          message: internal server error
+
+    OutputsResponse:
+      description: Returns a list of OutputIds.
+      properties:
+        data:
+          type: object
+          properties:
+            ledgerIndex:
+              type: integer
+              description: The current ledger index for which the request was made.
+            limit:
+              type: integer
+              description: The maximum count of results that are returned by the node.
+            offset:
+              type: integer
+              description: The offset to use for getting the next results.
+              nullable: true
+            count:
+              type: integer
+              description: The actual count of results that are returned.
+            outputIds:
+              type: array
+              description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
+          required:
+            - ledgerIndex
+            - limit
+            - count
+            - outputIds
+      required:
+        - data

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -182,7 +182,7 @@ paths:
       summary: Returns the outputId of the current unspent alias output for aliasId.
       description: Returns the outputId of the current unspent alias output for aliasId.
       parameters:
-        - in: query
+        - in: path
           name: aliasId
           schema:
             type: string
@@ -283,7 +283,7 @@ paths:
       summary: Returns the outputId of the current unspent foundry output for foundryId.
       description: Returns the outputId of the current unspent foundry output for foundryId.
       parameters:
-        - in: query
+        - in: path
           name: foundryId
           schema:
             type: string
@@ -420,7 +420,7 @@ paths:
       summary: Returns the outputId of the current unspent nft output for nftId.
       description: Returns the outputId of the current nft output for nftId.
       parameters:
-        - in: query
+        - in: path
           name: nftId
           schema:
             type: string

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -741,7 +741,7 @@ components:
           type: integer
           description: The current ledger index for which the request was made.
         cursor:
-          type: integer
+          type: string
           description: The cursor to use for getting the next page of results.
           nullable: true
         items:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -16,17 +16,17 @@ servers:
 tags:
   - name: basic outputs
     description: Query Basic Outputs.
-  - name: aliases
+  - name: alias outputs
     description: Query Alias Outputs.
-  - name: foundries
+  - name: foundry outputs
     description: Query Foundry Outputs.
-  - name: nfts
+  - name: nft outputs
     description: Query NFT Outputs.
 paths:
-  /api/plugins/indexer/v1/basic-outputs:
+  /api/plugins/indexer/v1/outputs/basic:
     get:
       tags:
-        - outputs
+        - basic outputs
       summary: Returns basic outputs filtered based on parameters.
       description: Returns basic outputs filtered based on parameters.
       parameters:
@@ -207,10 +207,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/aliases:
+  /api/plugins/indexer/v1/outputs/alias:
     get:
       tags:
-        - aliases
+        - alias outputs
       summary: Returns alias outputs filtered based on parameters.
       description: Returns alias outputs filtered based on parameters.
       parameters:
@@ -317,10 +317,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/aliases/{aliasId}:
+  /api/plugins/indexer/v1/outputs/alias/{aliasId}:
     get:
       tags:
-        - aliases
+        - alias outputs
       summary: Returns the outputId of the current unspent alias output for aliasId.
       description: Returns the outputId of the current unspent alias output for aliasId.
       parameters:
@@ -367,10 +367,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/foundries:
+  /api/plugins/indexer/v1/outputs/foundry:
     get:
       tags:
-        - foundries
+        - foundry outputs
       summary: Returns foundry outputs filtered based on parameters.
       description: Returns foundry outputs filtered based on parameters.
       parameters:
@@ -459,10 +459,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/foundries/{foundryId}:
+  /api/plugins/indexer/v1/outputs/foundry/{foundryId}:
     get:
       tags:
-        - foundries
+        - foundry outputs
       summary: Returns the outputId of the current unspent foundry output for foundryId.
       description: Returns the outputId of the current unspent foundry output for foundryId.
       parameters:
@@ -509,10 +509,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/nfts:
+  /api/plugins/indexer/v1/outputs/nft:
     get:
       tags:
-        - nfts
+        - nft outputs
       summary: Returns nft outputs filtered based on parameters.
       description: Returns nft outputs filtered based on parameters.
       parameters:
@@ -693,10 +693,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/nfts/{nftId}:
+  /api/plugins/indexer/v1/outputs/nft/{nftId}:
     get:
       tags:
-        - nfts
+        - nft outputs
       summary: Returns the outputId of the current unspent nft output for nftId.
       description: Returns the outputId of the current nft output for nftId.
       parameters:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -23,7 +23,7 @@ tags:
   - name: nft outputs
     description: Query NFT Outputs.
 paths:
-  /api/plugins/indexer/v1/outputs/basic:
+  /api/indexer/v1/outputs/basic:
     get:
       tags:
         - basic outputs
@@ -183,7 +183,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/alias:
+  /api/indexer/v1/outputs/alias:
     get:
       tags:
         - alias outputs
@@ -293,7 +293,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/alias/{aliasId}:
+  /api/indexer/v1/outputs/alias/{aliasId}:
     get:
       tags:
         - alias outputs
@@ -343,7 +343,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/foundry:
+  /api/indexer/v1/outputs/foundry:
     get:
       tags:
         - foundry outputs
@@ -435,7 +435,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/foundry/{foundryId}:
+  /api/indexer/v1/outputs/foundry/{foundryId}:
     get:
       tags:
         - foundry outputs
@@ -485,7 +485,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/nft:
+  /api/indexer/v1/outputs/nft:
     get:
       tags:
         - nft outputs
@@ -651,7 +651,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
 
-  /api/plugins/indexer/v1/outputs/nft/{nftId}:
+  /api/indexer/v1/outputs/nft/{nftId}:
     get:
       tags:
         - nft outputs

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -141,6 +141,12 @@ paths:
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
         - in: query
+          name: pageSize
+          schema:
+            type: integer
+          example: 10
+          description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
+        - in: query
           name: cursor
           schema:
             type: string
@@ -225,6 +231,12 @@ paths:
             type: integer
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+          example: 10
+          description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
         - in: query
           name: cursor
           schema:
@@ -342,6 +354,12 @@ paths:
             type: integer
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+          example: 10
+          description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
         - in: query
           name: cursor
           schema:
@@ -551,6 +569,12 @@ paths:
             type: integer
           example: 1643383242
           description: Return outputs that were created after a certain Unix timestamp.
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+          example: 10
+          description: The maximum amount of items returned in one call. If there are more items, a cursor to the next page is returned too.
         - in: query
           name: cursor
           schema:

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -375,10 +375,10 @@ paths:
       description: Returns foundry outputs filtered based on parameters.
       parameters:
         - in: query
-          name: address
+          name: aliasAddress
           schema:
             type: string
-          example: iota1ppk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn
+          example: iota1prlgpsht03ekmghhex8v7y67a835uns8dtlxu807hj0v279c74kj76j6rev
           description: Filter foundry outputs based on bech32-encoded address of the controlling alias.
         - in: query
           name: hasNativeTokens

--- a/tips/TIP-0026/indexer-rest-api.yaml
+++ b/tips/TIP-0026/indexer-rest-api.yaml
@@ -144,7 +144,7 @@ paths:
           name: tag
           schema:
             type: string
-          example: 4ec7f23
+          example: "0x4ec7f23"
           description: Filters outputs based on matching Tag Block.
         - in: query
           name: createdBefore
@@ -328,7 +328,7 @@ paths:
           name: aliasId
           schema:
             type: string
-          example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
+          example: "0xb098c0ee963575a8d505c299a99ce9c32cd4ecb3"
           description: Unique identifier of the alias.
           required: true
       responses:
@@ -470,7 +470,7 @@ paths:
           name: foundryId
           schema:
             type: string
-          example: b098c0ee963575a8d505c299a99ce9c32cd4ecb3
+          example: "0xb098c0ee963575a8d505c299a99ce9c32cd4ecb3"
           description: Unique identifier of the foundry.
           required: true
       responses:
@@ -630,7 +630,7 @@ paths:
           name: tag
           schema:
             type: string
-          example: 4ec7f23
+          example: "0x4ec7f23"
           description: Filters outputs based on matching Tag Block.
         - in: query
           name: createdBefore
@@ -704,7 +704,7 @@ paths:
           name: nftId
           schema:
             type: string
-          example: 4d09c5ef6a61766beb0b5655fdf0b379bac8a813
+          example: "0x4d09c5ef6a61766beb0b5655fdf0b379bac8a813"
           description: Unique identifier of the nft.
           required: true
       responses:
@@ -748,14 +748,14 @@ components:
       value:
         ledgerIndex: 101
         items:
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000"
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100"
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200"
     get-outputs-response-single-example:
       value:
         ledgerIndex: 101
         items:
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000"
     get-outputs-empty-response-example:
       value:
         ledgerIndex: 101
@@ -766,8 +766,8 @@ components:
         ledgerIndex: 101
         cursor: 61fa44a14d35ce14b9d0e7ee6ac9af70c0af156be269f69348be6d6f83c80a3a8a44ce440000.2
         items:
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000
-          - 0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000"
+          - "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100"
 
 
   schemas:
@@ -846,7 +846,7 @@ components:
           nullable: true
         items:
           type: array
-          description: The output IDs (transaction hash + output index) of the outputs satisfying the query.
+          description: The output IDs (transaction hash + output index) of the outputs satisfying the query. Hex-encoded with 0x prefix.
           items:
             type: string
       required:

--- a/tips/TIP-0026/tip-0013.md
+++ b/tips/TIP-0026/tip-0013.md
@@ -1,0 +1,25 @@
+---
+tip: 26
+title: UTXO Indexer API
+description: UTXO Indexer REST API routes and objects in OpenAPI Specification
+author: Levente Pap (@lzpap) <levente.pap@iota.org>
+discussions-to: https://github.com/iotaledger/tips/pull/26, https://github.com/iotaledger/tips/discussions/53
+status: Draft
+type: Standards
+layer: Interface
+created: 2022-01-27
+---
+
+# Summary
+
+This document proposes the UTXO Indexer REST API for nodes or applications supporting the IOTA protocol.
+
+# API
+
+The API is described using the OpenAPI Specification:
+
+[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml)
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0026/tip-0026.md
+++ b/tips/TIP-0026/tip-0026.md
@@ -18,7 +18,7 @@ This document proposes the UTXO Indexer REST API for nodes or applications suppo
 
 The API is described using the OpenAPI Specification:
 
-[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml)
+[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/indexer-api/tips/TIP-0026/indexer-rest-api.yaml)
 
 # Copyright
 

--- a/tips/TIP-0026/tip-0026.md
+++ b/tips/TIP-0026/tip-0026.md
@@ -3,7 +3,7 @@ tip: 26
 title: UTXO Indexer API
 description: UTXO Indexer REST API routes and objects in OpenAPI Specification
 author: Levente Pap (@lzpap) <levente.pap@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/26, https://github.com/iotaledger/tips/discussions/53
+discussions-to: https://github.com/iotaledger/tips/pull/62, https://github.com/iotaledger/tips/discussions/53
 status: Draft
 type: Standards
 layer: Interface

--- a/tips/TIP-0026/tip-0026.md
+++ b/tips/TIP-0026/tip-0026.md
@@ -10,16 +10,57 @@ layer: Interface
 created: 2022-01-27
 ---
 
-# Summary
+## Abstract
 
-This document proposes the UTXO Indexer REST API for nodes or applications supporting the IOTA protocol.
+The IOTA UTXO Indexer API defines the standard REST API interface that need to be fulfilled by indexer node plugins
+or standalone indexer applications.
 
-# API
+The purpose of the UTXO Indexer API is to:
+ - Provide access to structured, indexed records (outputs) of the UTXO ledger of the Tangle,
+ - Support client queries on the structured data to fetch outputs of interest,
+ - Offload network critical nodes from having to run the indexer application.
+
+## Motivation
+
+[TIP-18](https://github.com/iotaledger/tips/pull/38) introduces new output types into the IOTA UTXO ledger. These new
+outputs support a variety of new features such as different unlocking conditions and feature blocks.
+
+The indexer API makes it possible for clients to retrieve outputs based on present features, furthermore to filter them
+with more complex queries.
+
+The main client application the API is designed for are wallets, but it does not mean that other applications could
+not use or extend it.
+
+## Specification
 
 The API is described using the OpenAPI Specification:
 
 [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/indexer-api/tips/TIP-0026/indexer-rest-api.yaml)
 
-# Copyright
+## Rationale
+
+[This discussion](https://github.com/iotaledger/tips/discussions/53) gives a good overview of why the core and indexer
+APIs are separated. In short, indexing the ledger is considered to be a L2 application, and as such, it is not a
+mandatory part of IOTA core node implementations.
+
+Alternatively, all indexing could be baked into the core software that would require us to factor in the "cost" of
+indexing into byte cost of outputs, resulting in higher minimal dust deposit requirements. Network nodes that do not
+interact with clients but are the backbone of the network would also have to perform indexing tasks for no reason.
+
+The new architecture also opens up the door for developing more advanced indexing applications detached from node
+implementations.
+
+## Backwards Compatibility
+
+Some routes from the previous REST API ([TIP-13](../TIP-0013/tip-0013.md)) are removed and are supported in the new
+indexer API. For more details, browse [draft TIP-25](https://github.com/iotaledger/tips/pull/57).
+
+## Reference Implementation
+
+Hornet reference implementation:
+ - https://github.com/gohornet/hornet/tree/develop/plugins/indexer
+ - https://github.com/gohornet/hornet/tree/develop/pkg/indexer
+
+## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0026/tip-0026.md
+++ b/tips/TIP-0026/tip-0026.md
@@ -58,8 +58,7 @@ indexer API. For more details, browse [draft TIP-25](https://github.com/iotaledg
 ## Reference Implementation
 
 Hornet reference implementation:
- - https://github.com/gohornet/hornet/tree/develop/plugins/indexer
- - https://github.com/gohornet/hornet/tree/develop/pkg/indexer
+ - https://github.com/gohornet/inx-indexer
 
 ## Copyright
 


### PR DESCRIPTION
UTXO Indexer REST API specification for the Stardust update.

Complements #57 by exposing UTXO specific routes from an opt-in node indexer plugin or standalone application:
 - `api/indexer/v1/outputs/basic`: for fetching Basic Outputs
 -  `api/indexer/v1/outputs/alias`: for fetching Alias Outputs
 -  `api/indexer/v1/outputs/foundry`: for fetching Foundry Outputs
 -  `api/indexer/v1/outputs/nft`: for fetching NFT Outputs

All routes support additional query parameters to filter outputs based on content. The output objects can be fetched from the core API based on the returned `outputIds`.

[Rendered document](https://github.com/iotaledger/tips/blob/indexer-api/tips/TIP-0026/tip-0026.md)

