### PR TITLE
TIP-28 Node Event API

### DIFF
--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -139,7 +139,7 @@ channels:
     subscribe:
       tags:
         - name: transactions
-      operationId: transactions
+      operationId: transactionIncludedBlock
       description: Publishes the confirmed block which carried the transaction with the specified transaction id.
       message:
         $ref: '#/components/messages/Block'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -17,6 +17,8 @@ tags:
     description: Everything about outputs.
   - name: transactions
     description: Everything about transactions.
+  - name: receipts
+    description: Everything about migration receipts.
 channels:
   milestone-info/latest:
     subscribe:
@@ -250,6 +252,14 @@ channels:
       description: Publishes newly spent outputs that have a specific address in a specific unlock condition.
       message:
         $ref: '#/components/messages/OutputPayload'
+  receipts:
+    subscribe:
+      tags:
+       - name: receipts
+      operationId: receipts
+      description: Publishes newly created migration receipts in raw binary format.
+      message:
+        $ref: '#/components/messages/Receipt'
 
 
 components:
@@ -369,6 +379,14 @@ components:
         format: binary
         example: >-
           0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
+    Receipt:
+      contentType: application/octet-stream
+      description: The migration receipts in its serialized binary form.
+      payload:
+        type: string
+        format: binary
+        example: >-
+          010000000000000000000000000000000000000000000000000000000000000000000000000000000
     OutputPayload:
       contentType: application/json
       payload:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -1062,7 +1062,8 @@ components:
           example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
         outputIndex:
           type: number
-          description: The index of the this output within its transaction.
+          description: The index of the output within its transaction.
+
           example: 0
         isSpent:
           type: boolean

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -159,6 +159,43 @@ channels:
       description: Publishes newly spent outputs that have a specific address in a specific unlock condition.
       message:
         $ref: '#/components/messages/OutputPayload'
+  outputs/aliases/{aliasId}:
+    parameters:
+      aliasId:
+        description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x6457f5f1bc2c3ec696889309cee0665c298f6394"
+    subscribe:
+      operationId: aliasOutputByAliasId
+      description: Publishes the newly created alias output of an alias chain.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/nfts/{nftId}:
+    parameters:
+      nftId:
+        description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd"
+    subscribe:
+      operationId: nftOutputByNftId
+      description: Publishes the newly created nft output of an nft chain.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/foundries/{foundryId}:
+    parameters:
+      foundryId:
+        description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x0868cebac478305970c1be92c4b4c54f7dc5eb3e790100000000"
+    subscribe:
+      operationId: foundryOutputByFoundryId
+      description: Publishes the newly created foundry output of a foundry chain.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+
 components:
   messages:
     MilestonePayload:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -895,7 +895,8 @@ components:
           example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          description: Unlock condtions that define how the output can be unlocked in a transaction.
+
           items:
             anyOf:
               - $ref: '#/components/schemas/AddressUnlockCondition'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -157,7 +157,7 @@ channels:
       description: Publishes the given wanted output on subscription and when its state changes (created, spent).
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/aliases/{aliasId}:
+  outputs/alias/{aliasId}:
     parameters:
       aliasId:
         description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
@@ -171,7 +171,7 @@ channels:
       description: Publishes the newly created alias output of an alias chain.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/nfts/{nftId}:
+  outputs/nft/{nftId}:
     parameters:
       nftId:
         description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
@@ -185,7 +185,7 @@ channels:
       description: Publishes the newly created nft output of an nft chain.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/foundries/{foundryId}:
+  outputs/foundry/{foundryId}:
     parameters:
       foundryId:
         description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -623,7 +623,8 @@ components:
       properties:
         type:
           type: integer
-          description: Set to value 5 to denote an  Governor Address Unlock Condition.
+          description: Set to value 5 to denote a Governor Address Unlock Condition.
+
           example: 5
         address:
           oneOf:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -570,7 +570,8 @@ components:
       properties:
         type:
           type: integer
-          description: Set to value 2 to denote an Timelock Unlock Condition.
+          description: Set to value 2 to denote a Timelock Unlock Condition.
+
           example: 2
         unixTime:
           type: integer

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -25,7 +25,7 @@ channels:
       operationId: milestoneInfoLatest
       tags:
         - name: milestones
-      description: Publishes the newest latest known milestone index and its timestamp.
+      description: Publishes the latest known milestone index and its timestamp.
       message:
         $ref: '#/components/messages/MilestoneInfoResponse'
   milestone-info/confirmed:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -320,11 +320,11 @@ components:
             example:
               - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
               - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
-          pastConeMerkleProof:
+          inclusionMerkleRoot:
             type: string
             description: The merkle root of all directly/indirectly referenced blocks (their IDs) which were newly confirmed by this milestone.
             example: "0x014e3a82d54c1bf4e411eee30ce25ee739b0f790fca248c0036d538952d6072b"
-          inclusionMerkleProof:
+          appliedMerkleRoot:
             type: string
             description: The merkle root of all blocks (their IDs) carrying ledger state mutating transactions.
             example: "0x07fbcf40a98cf1e1e1e0aeb7527ecf464cc8d461f617e48931c6a2096cb18d1a"
@@ -997,13 +997,15 @@ components:
         targetMilestoneIndex:
           type: integer
           description: The milestone index at which these protocol parameters become active.
+          example: 123456
         protocolVersion:
           type: integer
           description: The to be applied protocol version.
+          example: 3
         params:
           type: string
           description: The protocol parameters in binary form. Hex-encoded with 0x prefix.
-          example: 150
+          example: "0x174612e0a436f756e743a203037323935320a54696d657374616d703a203132372e3030302e3030302e303030"
       required:
         - type
         - targetMilestoneIndex

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -1,10 +1,12 @@
-asyncapi: 2.0.0
+asyncapi: 2.4.0
 info:
   title: Node Event API
   contact:
     email: contact@iota.org
   version: 2.0.0
-  description: The node event API is in charge of publishing information about events within the node software.
+  description: >-
+    The node event API is in charge of publishing information about events
+    within the node software.
 externalDocs:
   description: Find out more about IOTA
   url: 'https://iota.org'
@@ -58,7 +60,9 @@ channels:
         - name: blocks
         - name: transactions
       operationId: blocksTransaction
-      description: Publishes newly received blocks containing a transaction payload in their serialized binary form.
+      description: >-
+        Publishes newly received blocks containing a transaction payload in
+        their serialized binary form.
       message:
         $ref: '#/components/messages/Block'
   blocks/transaction/tagged-data:
@@ -67,22 +71,29 @@ channels:
         - name: blocks
         - name: transactions
       operationId: blocksTransactionsWithTaggedData
-      description: Publishes newly received blocks containing a Tagged Data payload inside transactions.
+      description: >-
+        Publishes newly received blocks containing a Tagged Data payload inside
+        transactions.
       message:
         $ref: '#/components/messages/Block'
-  blocks/transaction/tagged-data/{tag}:
+  'blocks/transaction/tagged-data/{tag}':
     parameters:
       tag:
-        description: Hex encoded tag of the Tagged Data Payload inside the Transaction Payload.
+        description: >-
+          Hex encoded tag of the Tagged Data Payload inside the Transaction
+          Payload.
         schema:
           type: string
-          example: "0xe45"
+          examples:
+            - '0xe45'
     subscribe:
       tags:
         - name: blocks
         - name: transactions
       operationId: blocksTransactionsWithTag
-      description: Publishes newly received blocks containing a Tagged Data payload inside transactions with a specific tag.
+      description: >-
+        Publishes newly received blocks containing a Tagged Data payload inside
+        transactions with a specific tag.
       message:
         $ref: '#/components/messages/Block'
   blocks/tagged-data:
@@ -90,30 +101,37 @@ channels:
       tags:
         - name: blocks
       operationId: blocksWithTaggedData
-      description: Publishes newly received blocks which contain tagged data payloads (encoded in hex) in their serialized binary form.
+      description: >-
+        Publishes newly received blocks which contain tagged data payloads
+        (encoded in hex) in their serialized binary form.
       message:
         $ref: '#/components/messages/Block'
-  blocks/tagged-data/{tag}:
+  'blocks/tagged-data/{tag}':
     parameters:
       tag:
         description: Hex encoded tag of the Tagged Data Payload.
         schema:
           type: string
-          example: "0xe45"
+          examples:
+            - '0xe45'
     subscribe:
       tags:
         - name: blocks
       operationId: blocksWithSpecificTag
-      description: Publishes newly received blocks which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data blocks do not get published.
+      description: >-
+        Publishes newly received blocks which contain tagged data payloads with
+        the specified tag parameter (encoded in hex) in their serialized binary
+        form. Untagged data blocks do not get published.
       message:
         $ref: '#/components/messages/Block'
-  block-metadata/{blockId}:
+  'block-metadata/{blockId}':
     parameters:
       blockId:
         description: Hex encoded identifier of the block.
         schema:
           type: string
-          example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          examples:
+            - '0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85'
     subscribe:
       tags:
         - name: blocks
@@ -129,41 +147,48 @@ channels:
       description: Publishes metadata of a block whenever it gets referenced.
       message:
         $ref: '#/components/messages/BlockMetadata'
-  transactions/{transactionId}/included-block:
+  'transactions/{transactionId}/included-block':
     parameters:
       transactionId:
         description: Hex encoded identifier of the transaction.
         schema:
           type: string
-          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+          examples:
+            - '0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7'
     subscribe:
       tags:
         - name: transactions
       operationId: transactionIncludedBlock
-      description: Publishes the confirmed block which carried the transaction with the specified transaction id.
+      description: >-
+        Publishes the confirmed block which carried the transaction with the
+        specified transaction id.
       message:
         $ref: '#/components/messages/Block'
-  outputs/{outputId}:
+  'outputs/{outputId}':
     parameters:
       outputId:
         description: Hex encoded identifier of the output.
         schema:
           type: string
-          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be70000"
+          examples:
+            - '0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be70000'
     subscribe:
       tags:
         - name: outputs
       operationId: output
-      description: Publishes the given wanted output on subscription and when its state changes (created, spent).
+      description: >-
+        Publishes the given wanted output on subscription and when its state
+        changes (created, spent).
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/alias/{aliasId}:
+  'outputs/alias/{aliasId}':
     parameters:
       aliasId:
         description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
         schema:
           type: string
-          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
+          examples:
+            - '0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6'
     subscribe:
       tags:
         - name: outputs
@@ -171,13 +196,14 @@ channels:
       description: Publishes the newly created alias output of an alias chain.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/nft/{nftId}:
+  'outputs/nft/{nftId}':
     parameters:
       nftId:
         description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
         schema:
           type: string
-          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
+          examples:
+            - '0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f'
     subscribe:
       tags:
         - name: outputs
@@ -185,13 +211,16 @@ channels:
       description: Publishes the newly created nft output of an nft chain.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/foundry/{foundryId}:
+  'outputs/foundry/{foundryId}':
     parameters:
       foundryId:
-        description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.
+        description: >-
+          The unique identifier of the foundry chain. Hex encoded with 0x
+          prefix.
         schema:
           type: string
-          example: "0x081505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d60100000000"
+          examples:
+            - '0x081505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d60100000000'
     subscribe:
       tags:
         - name: outputs
@@ -199,68 +228,72 @@ channels:
       description: Publishes the newly created foundry output of a foundry chain.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/unlock/{condition}/{address}:
+  'outputs/unlock/{condition}/{address}':
     parameters:
       condition:
         description: Type of unlock condition of the output to look for.
         schema:
           type: string
           enum:
-            - "address"
-            - "storage-return"
-            - "expiration"
-            - "state-controller"
-            - "governor"
-            - "immutable-alias"
-            - "+"
+            - address
+            - storage-return
+            - expiration
+            - state-controller
+            - governor
+            - immutable-alias
+            - +
       address:
         description: Bech32 encoded address.
         schema:
           type: string
-          example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
+          examples:
+            - 'iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v'
     subscribe:
       tags:
         - name: outputs
       operationId: outputByUnlockAndAddress
-      description: Publishes newly created outputs that have a specific address in a specific unlock condition.
+      description: >-
+        Publishes newly created outputs that have a specific address in a
+        specific unlock condition.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/unlock/{condition}/{address}/spent:
+  'outputs/unlock/{condition}/{address}/spent':
     parameters:
       condition:
         description: Type of unlock condition of the output to look for.
         schema:
           type: string
           enum:
-            - "address"
-            - "storage-return"
-            - "expiration"
-            - "state-controller"
-            - "governor"
-            - "immutable-alias"
-            - "+"
+            - address
+            - storage-return
+            - expiration
+            - state-controller
+            - governor
+            - immutable-alias
+            - +
       address:
         description: Bech32 encoded address.
         schema:
           type: string
-          example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
+          examples:
+            - 'iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v'
     subscribe:
       tags:
         - name: outputs
       operationId: outputByUnlockAndAddressSpent
-      description: Publishes newly spent outputs that have a specific address in a specific unlock condition.
+      description: >-
+        Publishes newly spent outputs that have a specific address in a specific
+        unlock condition.
       message:
         $ref: '#/components/messages/OutputPayload'
   receipts:
     subscribe:
       tags:
-       - name: receipts
+        - name: receipts
       operationId: receipts
       description: Publishes newly created migration receipts in raw binary format.
       message:
         $ref: '#/components/messages/Receipt'
-
-
 components:
   messages:
     MilestonePayload:
@@ -268,14 +301,14 @@ components:
       payload:
         type: object
         required:
-          - "type"
-          - "index"
-          - "timestamp"
-          - "previousMilestoneId"
-          - "parents"
-          - "pastConeMerkleProof"
-          - "inclusionMerkleProof"
-          - "signatures"
+          - type
+          - index
+          - timestamp
+          - previousMilestoneId
+          - parents
+          - pastConeMerkleProof
+          - inclusionMerkleProof
+          - signatures
         properties:
           type:
             type: number
@@ -291,42 +324,51 @@ components:
             example: 1609950538
           protocolVersion:
             type: integer
-            description: Protocol version of the Milestone Payload and its encapsulating block.
+            description: >-
+              Protocol version of the Milestone Payload and its encapsulating
+              block.
             example: 2
           previousMilestoneId:
             type: string
-            description: Milestone ID of the previous milestone (index - 1). Hex-encoded with 0x prefix.
-            example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"
+            description: >-
+              Milestone ID of the previous milestone (index - 1). Hex-encoded
+              with 0x prefix.
+            example: '0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e'
           parents:
             type: array
             description: The parents where this milestone attaches to
             example:
-              - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
-              - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+              - >-
+                0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7
+              - >-
+                0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85
           inclusionMerkleRoot:
             type: string
-            description: The merkle root of all directly/indirectly referenced blocks (their IDs) which were newly confirmed by this milestone.
-            example: "0x014e3a82d54c1bf4e411eee30ce25ee739b0f790fca248c0036d538952d6072b"
+            description: >-
+              The merkle root of all directly/indirectly referenced blocks
+              (their IDs) which were newly confirmed by this milestone.
+            example: '0x014e3a82d54c1bf4e411eee30ce25ee739b0f790fca248c0036d538952d6072b'
           appliedMerkleRoot:
             type: string
-            description: The merkle root of all blocks (their IDs) carrying ledger state mutating transactions.
-            example: "0x07fbcf40a98cf1e1e1e0aeb7527ecf464cc8d461f617e48931c6a2096cb18d1a"
+            description: >-
+              The merkle root of all blocks (their IDs) carrying ledger state
+              mutating transactions.
+            example: '0x07fbcf40a98cf1e1e1e0aeb7527ecf464cc8d461f617e48931c6a2096cb18d1a'
           metadata:
             type: string
             descripiton: The metadata associated with this milestone.
-            example: "0x01"
+            example: '0x01'
           options:
             type: array
             items:
-             anyOf:
-               - $ref: '#/components/schemas/ReceiptMilestoneOpt'
-               - $ref: '#/components/schemas/ProtocolParamsMilestoneOptions'
+              anyOf:
+                - $ref: '#/components/schemas/ReceiptMilestoneOpt'
+                - $ref: '#/components/schemas/ProtocolParamsMilestoneOptions'
           signatures:
             type: array
             items:
               anyOf:
                 - $ref: '#/components/schemas/Ed25519Signature'
-
     MilestonePayloadSerialized:
       contentType: application/vnd.iota.serializer-v1
       description: The milestone payload in its serialized form.
@@ -335,13 +377,12 @@ components:
         format: binary
         example: >-
           070000000a1a0000977c626276b19ef8b3c445709f2f0f2ccc4abb98d97617f421f240c0d1ee066d4306e67a0321889ef8ec89b7eff1378049e058f0fa87a78c2452ae72631a5a99d913d1cbb3525b8faa1800e28dfcb28154bcba10154c39ef87ceda793cb44f58ae1549c88ea13fe4a9695bb6f0aba6cb756522209e5066a96039ae12b398b975693bdc21e222997c86ff9bfc5844f0372d58ff6fa510688e53c181bbdf4db41f9b627540a70e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a80000000300d85e5b1590d898d1e0cdebb2e3b5337c8b76270142663d78811683ba47c17c989ad7a8f0ff2c6438bf435786d4a5b0125a5caf7367061b49a739389d5ebea234c0466c86f88a3f8add03bff04c2e34b214683f2f6983641e1d1185da7e2c3e0200d9922819a39e94ddf3907f4b9c8df93f39f026244fcb609205b9a879022599f218be2536d8b7b8547faa3dbdfe98339ebe9e2b2417a8a03eee02b2a8312b9e026dd0a33261a58a240cd0a1b06cdf1775d98d316f162d3eec402f4bf08bea2a0700f9d9656a60049083eef61487632187b351294c1fa23d118060d813db6d03e8b6ca8180d435708e826bc2042ccd667babb59c5cc461ff29dba966359fcd6fc511cdfdf10d6576f36ac2a6e5cb691e13968c13947ffbd9239939d3802b2fbe0f06
-
     MilestoneInfoResponse:
       contentType: application/json
       payload:
         type: object
         required:
-          - "milestoneIndex"
+          - milestoneIndex
         properties:
           milestoneIndex:
             type: number
@@ -354,8 +395,7 @@ components:
           milestoneId:
             type: string
             description: Hex encoded identifier of the milestone payload.
-            example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
-
+            example: '0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695'
     Block:
       contentType: application/vnd.iota.serializer-v1
       description: The block in its serialized binary form.
@@ -377,8 +417,8 @@ components:
       payload:
         type: object
         required:
-          - "metadata"
-          - "output"
+          - metadata
+          - output
         properties:
           metadata:
             type: object
@@ -398,20 +438,22 @@ components:
       payload:
         type: object
         required:
-          - "blockId"
-          - "parents"
-          - "isSolid"
+          - blockId
+          - parents
+          - isSolid
         properties:
           blockId:
             type: string
             description: The ID of the block.
-            example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+            example: '0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85'
           parents:
             type: array
             description: The IDs of the referenced parent blocks.
             example:
-              - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
-              - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+              - >-
+                0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7
+              - >-
+                0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85
           isSolid:
             type: boolean
             description: Whether the block is solid or not.
@@ -423,12 +465,28 @@ components:
           ledgerInclusionState:
             type: string
             description: The inclusion state of the block.
-            enum: [ noTransaction, conflicting, included ]
+            enum:
+              - noTransaction
+              - conflicting
+              - included
             example: conflicting
           conflictReason:
             type: integer
-            enum: [ 1,2,3,4,5,6,7,8,9,10,11,12,255 ]
-            description: >
+            enum:
+              - 1
+              - 2
+              - 3
+              - 4
+              - 5
+              - 6
+              - 7
+              - 8
+              - 9
+              - 10
+              - 11
+              - 12
+              - 255
+            description: |
               Values:
                 * `1` - denotes that the referenced UTXO was already spent.
                 * `2` - denotes that the referenced UTXO was already spent while confirming this milestone.
@@ -446,29 +504,38 @@ components:
             example: 1
           whiteFlagIndex:
             type: integer
-            description: If set, defines the order of the block in the white flag traversal during milestone solidification. Only referenced blocks have this information.
+            description: >-
+              If set, defines the order of the block in the white flag traversal
+              during milestone solidification. Only referenced blocks have this
+              information.
             example: 13
           shouldPromote:
             type: boolean
-            description: Whether the block should be promoted. This is determined automatically by the node by using the OCRI/YCRI of the block.
+            description: >-
+              Whether the block should be promoted. This is determined
+              automatically by the node by using the OCRI/YCRI of the block.
             example: true
           shouldReattach:
             type: boolean
-            description: Whether the block should be re-attached. This is determined automatically by the node by using the OCRI/YCRI of the block.
+            description: >-
+              Whether the block should be re-attached. This is determined
+              automatically by the node by using the OCRI/YCRI of the block.
             example: false
-
   schemas:
     NativeToken:
       description: A native token and its balance in the output.
       properties:
         tokenId:
           type: string
-          description: Hex-encoded identifier of the native token that equals the foundryId of the controlling foundry.
-          example: "0x08de3fa7acc30ec899bb797b1d80680690b54a1cdb78b2f7f50b1ad073e74c8cbd0100000000"
+          description: >-
+            Hex-encoded identifier of the native token that equals the foundryId
+            of the controlling foundry.
+          example: >-
+            0x08de3fa7acc30ec899bb797b1d80680690b54a1cdb78b2f7f50b1ad073e74c8cbd0100000000
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex encoded number.
-          example: "0xc8"
+          example: '0xc8'
       required:
         - tokenId
         - amount
@@ -482,7 +549,7 @@ components:
         pubKeyHash:
           type: string
           description: The hex-encoded BLAKE2b-256 hash of the Ed25519 public key.
-          example: "0x713c3e879b53398431f67312254101ffdd23067febc77f4949de57ee279c8bee"
+          example: '0x713c3e879b53398431f67312254101ffdd23067febc77f4949de57ee279c8bee'
       required:
         - type
         - pubKeyHash
@@ -495,8 +562,10 @@ components:
           example: 1
         aliasId:
           type: string
-          description: The hex-encoded BLAKE2b-256 hash of the outputId that created the alias.
-          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
+          description: >-
+            The hex-encoded BLAKE2b-256 hash of the outputId that created the
+            alias.
+          example: '0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6'
       required:
         - type
         - aliasId
@@ -509,8 +578,10 @@ components:
           example: 1
         nftId:
           type: string
-          description: The hex-encoded BLAKE2b-256 hash of the outputId that created the NFT.
-          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
+          description: >-
+            The hex-encoded BLAKE2b-256 hash of the outputId that created the
+            NFT.
+          example: '0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f'
       required:
         - type
         - nftId
@@ -530,12 +601,16 @@ components:
         - type
         - address
     ImmutableAliasAddressUnlockCondition:
-      description: Can be unlocked by unlocking the permanent alias address.
-        The unlock condition has to be kept in future state transitions of the UTXO state machine.
+      description: >-
+        Can be unlocked by unlocking the permanent alias address. The unlock
+        condition has to be kept in future state transitions of the UTXO state
+        machine.
       properties:
         type:
           type: integer
-          description: Set to value 6 to denote an Immutable Alias Address Unlock Condition.
+          description: >-
+            Set to value 6 to denote an Immutable Alias Address Unlock
+            Condition.
           example: 6
         address:
           oneOf:
@@ -544,13 +619,13 @@ components:
         - type
         - address
     StorageDepositReturnUnlockCondition:
-      description: Can be unlocked by depositing return amount to return address via an output that only has Address Unlock Condition.
-
+      description: >-
+        Can be unlocked by depositing return amount to return address via an
+        output that only has Address Unlock Condition.
       properties:
         type:
           type: integer
           description: Set to value 1 to denote a Storage Deposit Return Unlock Condition.
-
           example: 1
         returnAddress:
           oneOf:
@@ -559,7 +634,9 @@ components:
             - $ref: '#/components/schemas/NFTAddress'
         returnAmount:
           type: integer
-          description: Amount of IOTA tokens the consuming transaction should deposit to the address defined in Return Address.
+          description: >-
+            Amount of IOTA tokens the consuming transaction should deposit to
+            the address defined in Return Address.
           example: 50
       required:
         - type
@@ -571,18 +648,22 @@ components:
         type:
           type: integer
           description: Set to value 2 to denote a Timelock Unlock Condition.
-
           example: 2
         unixTime:
           type: integer
-          description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
+          description: >-
+            Unix time (seconds since Unix epoch) starting from which the output
+            can be consumed.
           example: 1609950538
           exclusiveMinimum: 0
       required:
         - type
         - unixTime
     ExpirationUnlockCondition:
-      description: Defines a unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the unix time, only Return Address can unlock it.
+      description: >-
+        Defines a unix time until which only Address, defined in Address Unlock
+        Condition, is allowed to unlock the output. After the unix time, only
+        Return Address can unlock it.
       properties:
         type:
           type: integer
@@ -595,7 +676,9 @@ components:
             - $ref: '#/components/schemas/NFTAddress'
         unixTime:
           type: integer
-          description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
+          description: >-
+            Before this unix time, Address Unlock Condition is allowed to unlock
+            the output, after that only the address defined in Return Address.
           example: 1609950538
           exclusiveMinimum: 0
       required:
@@ -608,7 +691,6 @@ components:
         type:
           type: integer
           description: Set to value 4 to denote a Sate Controller Address Unlock Condition.
-
           example: 4
         address:
           oneOf:
@@ -624,7 +706,6 @@ components:
         type:
           type: integer
           description: Set to value 5 to denote a Governor Address Unlock Condition.
-
           example: 5
         address:
           oneOf:
@@ -665,7 +746,9 @@ components:
         - type
         - issuer
     MetadataFeature:
-      description: Defines metadata (arbitrary binary data) that will be stored in the output.
+      description: >-
+        Defines metadata (arbitrary binary data) that will be stored in the
+        output.
       properties:
         type:
           type: integer
@@ -674,12 +757,14 @@ components:
         data:
           type: string
           description: Hex-encoded binary data.
-          example: "0xfa0de75d225cca2799395e5fc340702fc7eac8"
+          example: '0xfa0de75d225cca2799395e5fc340702fc7eac8'
       required:
         - type
         - data
     TagFeature:
-      description: Defines an indexation tag to which the output can be indexed by additional node plugins.
+      description: >-
+        Defines an indexation tag to which the output can be indexed by
+        additional node plugins.
       properties:
         type:
           type: integer
@@ -688,12 +773,15 @@ components:
         tag:
           type: string
           description: Hex-encoded binary indexation tag.
-          example: "0xfa0de75"
+          example: '0xfa0de75'
       required:
         - type
         - tag
     SimpleTokenScheme:
-      description: Defines the simple supply control scheme of native tokens. Tokens can be minted by the foundry without additional restrictions as long as maximum supply is requested and circulating supply is not negative.
+      description: >-
+        Defines the simple supply control scheme of native tokens. Tokens can be
+        minted by the foundry without additional restrictions as long as maximum
+        supply is requested and circulating supply is not negative.
       properties:
         type:
           type: integer
@@ -702,15 +790,17 @@ components:
         mintedTokens:
           type: string
           description: Minted tokens controlled by this foundry. Hex encoded number.
-          example: "0x2710"
+          example: '0x2710'
         meltedTokens:
           type: string
           description: Melted tokens controlled by this foundry. Hex encoded number.
-          example: "0x1388"
+          example: '0x1388'
         maxSupply:
           type: string
-          description: Maximum supply of tokens controlled by this foundry. Hex encoded number.
-          example: "0x186a0"
+          description: >-
+            Maximum supply of tokens controlled by this foundry. Hex encoded
+            number.
+          example: '0x186a0'
       required:
         - type
         - mintedTokens
@@ -725,18 +815,21 @@ components:
           example: 3
         amount:
           type: string
-          description: The amount of IOTA tokens to deposit with this BasicOutput output. Encoded as plain string.
-          example: "100"
+          description: >-
+            The amount of IOTA tokens to deposit with this BasicOutput output.
+            Encoded as plain string.
+          example: '100'
         nativeTokens:
-           type: array
-           description: Native tokens held by the otuput.
-           items:
-             anyOf:
-               - $ref: '#/components/schemas/NativeToken'
+          type: array
+          description: Native tokens held by the otuput.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/NativeToken'
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output can be unlocked in a transaction.
-
+          description: >-
+            Unlock condtions that define how the output can be unlocked in a
+            transaction.
           items:
             anyOf:
               - $ref: '#/components/schemas/AddressUnlockCondition'
@@ -745,18 +838,22 @@ components:
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
         features:
           type: array
-          description: Features that add utility to the output but do not impose unlocking conditions.
+          description: >-
+            Features that add utility to the output but do not impose unlocking
+            conditions.
           items:
             anyOf:
               - $ref: '#/components/schemas/SenderFeature'
               - $ref: '#/components/schemas/MetadataFeature'
               - $ref: '#/components/schemas/TagFeature'
       required:
-       - type
-       - amount
-       - unlockConditions
+        - type
+        - amount
+        - unlockConditions
     AliasOutput:
-      description: Describes an alias account in the ledger that can be controlled by the state and governance controllers.
+      description: >-
+        Describes an alias account in the ledger that can be controlled by the
+        state and governance controllers.
       properties:
         type:
           type: integer
@@ -764,8 +861,10 @@ components:
           example: 4
         amount:
           type: string
-          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
-          example: "100"
+          description: >-
+            The amount of IOTA tokens to deposit with this output. Encoded as
+            plain string.
+          example: '100'
         nativeTokens:
           type: array
           description: Native tokens held by the otuput.
@@ -774,40 +873,53 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         aliasId:
           type: string
-          description: Unique identifier of the alias, which is the BLAKE2b-256 hash of the Output ID that created it.
-            Alias Address = Alias Address Type || Alias ID
-          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
+          description: >-
+            Unique identifier of the alias, which is the BLAKE2b-256 hash of the
+            Output ID that created it. Alias Address = Alias Address Type ||
+            Alias ID
+          example: '0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6'
         stateIndex:
           type: integer
-          description: A counter that must increase by 1 every time the alias is state transitioned.
+          description: >-
+            A counter that must increase by 1 every time the alias is state
+            transitioned.
           example: 1337
         stateMetadata:
           type: string
-          description: Hex-encoded metadata that can only be changed by the state controller.
-          example: "0x7665727920696d706f7274616e74207374617465206d65746164617461"
+          description: >-
+            Hex-encoded metadata that can only be changed by the state
+            controller.
+          example: '0x7665727920696d706f7274616e74207374617465206d65746164617461'
         foundryCounter:
           type: integer
-          description: A counter that denotes the number of foundries created by this alias account.
+          description: >-
+            A counter that denotes the number of foundries created by this alias
+            account.
           example: 3
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output can be unlocked in a transaction.
-
+          description: >-
+            Unlock condtions that define how the output can be unlocked in a
+            transaction.
           items:
             anyOf:
               - $ref: '#/components/schemas/StateControllerAddressUnlockCondition'
               - $ref: '#/components/schemas/GovernorAddressUnlockCondition'
         features:
           type: array
-          description: Features that add utility to the output but do not impose unlocking conditions.
+          description: >-
+            Features that add utility to the output but do not impose unlocking
+            conditions.
           items:
             anyOf:
               - $ref: '#/components/schemas/SenderFeature'
               - $ref: '#/components/schemas/MetadataFeature'
         immutableFeatures:
           type: array
-          description: Immutable features that add utility to the output but do not impose unlocking conditions.
-            These blocks need to be kept in future transitions of the UTXO state machine.
+          description: >-
+            Immutable features that add utility to the output but do not impose
+            unlocking conditions. These blocks need to be kept in future
+            transitions of the UTXO state machine.
           items:
             anyOf:
               - $ref: '#/components/schemas/IssuerFeature'
@@ -828,8 +940,10 @@ components:
           example: 5
         amount:
           type: string
-          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
-          example: "100"
+          description: >-
+            The amount of IOTA tokens to deposit with this output. Encoded as
+            plain string.
+          example: '100'
         nativeTokens:
           type: array
           description: Native tokens held by the otuput.
@@ -838,31 +952,40 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         serialNumber:
           type: integer
-          description: The serial number of the foundry with respect to the controlling alias.
+          description: >-
+            The serial number of the foundry with respect to the controlling
+            alias.
           example: 2
         tokenScheme:
           type: array
-          description: Defines the supply control scheme of the tokens controlled by the foundry.
+          description: >-
+            Defines the supply control scheme of the tokens controlled by the
+            foundry.
           items:
             oneOf:
               - $ref: '#/components/schemas/SimpleTokenScheme'
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output can be unlocked in a transaction.
-
+          description: >-
+            Unlock condtions that define how the output can be unlocked in a
+            transaction.
           items:
             anyOf:
               - $ref: '#/components/schemas/ImmutableAliasAddressUnlockCondition'
         features:
           type: array
-          description: Features that add utility to the output but do not impose unlocking conditions.
+          description: >-
+            Features that add utility to the output but do not impose unlocking
+            conditions.
           items:
             anyOf:
               - $ref: '#/components/schemas/MetadataFeature'
         immutableFeatures:
           type: array
-          description: Immutable features that add utility to the output but do not impose unlocking conditions.
-            These blocks need to be kept in future transitions of the UTXO state machine.
+          description: >-
+            Immutable features that add utility to the output but do not impose
+            unlocking conditions. These blocks need to be kept in future
+            transitions of the UTXO state machine.
           items:
             anyOf:
               - $ref: '#/components/schemas/MetadataFeature'
@@ -873,16 +996,17 @@ components:
         - tokenScheme
         - unlockConditions
     NFTOutput:
-      description: Describes an NFT output, a globally unique token with metadata attached.
-
+      description: 'Describes an NFT output, a globally unique token with metadata attached.'
       properties:
         type:
           type: integer
           description: Set to value 6 to denote a NFT Output.
         amount:
           type: string
-          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
-          example: "100"
+          description: >-
+            The amount of IOTA tokens to deposit with this output. Encoded as
+            plain string.
+          example: '100'
         nativeTokens:
           type: array
           description: Native tokens held by the otuput.
@@ -891,12 +1015,15 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         nftId:
           type: string
-          description: Unique identifier of the NFT, which is the BLAKE2b-256 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID
-          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
+          description: >-
+            Unique identifier of the NFT, which is the BLAKE2b-256 hash of the
+            Output ID that created it. NFT Address = NFT Address Type || NFT ID
+          example: '0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f'
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output can be unlocked in a transaction.
-
+          description: >-
+            Unlock condtions that define how the output can be unlocked in a
+            transaction.
           items:
             anyOf:
               - $ref: '#/components/schemas/AddressUnlockCondition'
@@ -905,7 +1032,9 @@ components:
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
         features:
           type: array
-          description: Features that add utility to the output but do not impose unlocking conditions.
+          description: >-
+            Features that add utility to the output but do not impose unlocking
+            conditions.
           items:
             anyOf:
               - $ref: '#/components/schemas/SenderFeature'
@@ -914,9 +1043,12 @@ components:
               - $ref: '#/components/schemas/TagFeature'
         immutableFeatures:
           type: array
-          description: Immutable features that add utility to the output but do not impose unlocking conditions.
+          description: >-
+            Immutable features that add utility to the output but do not impose
+            unlocking conditions.
 
-            These blocks need to be kept in future transitions of the UTXO state machine.
+            These blocks need to be kept in future transitions of the UTXO state
+            machine.
           items:
             anyOf:
               - $ref: '#/components/schemas/IssuerFeature'
@@ -925,7 +1057,6 @@ components:
         - type
         - amount
         - unlockConditions
-
     TreasuryInput:
       properties:
         type:
@@ -937,7 +1068,6 @@ components:
       required:
         - type
         - milestoneId
-
     TreasuryOutput:
       properties:
         type:
@@ -946,11 +1076,9 @@ components:
         amount:
           type: string
           description: Amount of IOTA tokens in the treasury. Plain string encoded number.
-
       required:
         - type
         - amount
-
     TreasuryTransactionPayload:
       properties:
         type:
@@ -966,7 +1094,6 @@ components:
         - type
         - input
         - output
-
     MigratedFundsEntry:
       properties:
         tailTransactionHash:
@@ -980,9 +1107,10 @@ components:
         - tailTransactionHash
         - address
         - deposit
-
     ReceiptMilestoneOpt:
-      description: Contains a receipt and the index of the milestone which contained the receipt.
+      description: >-
+        Contains a receipt and the index of the milestone which contained the
+        receipt.
       properties:
         type:
           type: integer
@@ -1003,7 +1131,6 @@ components:
         - funds
         - transaction
         - type
-
     ProtocolParamsMilestoneOptions:
       description: Defines changing protocol parameters.
       properties:
@@ -1013,7 +1140,9 @@ components:
           example: 1
         targetMilestoneIndex:
           type: integer
-          description: The milestone index at which these protocol parameters become active.
+          description: >-
+            The milestone index at which these protocol parameters become
+            active.
           example: 123456
         protocolVersion:
           type: integer
@@ -1022,13 +1151,13 @@ components:
         params:
           type: string
           description: The protocol parameters in binary form. Hex-encoded with 0x prefix.
-          example: "0x174612e0a436f756e743a203037323935320a54696d657374616d703a203132372e3030302e3030302e303030"
+          example: >-
+            0x174612e0a436f756e743a203037323935320a54696d657374616d703a203132372e3030302e3030302e303030
       required:
         - type
         - targetMilestoneIndex
         - protocolVersion
         - params
-
     Ed25519Signature:
       description: Ed25519Signature defines an Ed25519 signature.
       properties:
@@ -1039,31 +1168,29 @@ components:
         publicKey:
           type: string
           description: The public key used to verify the given signature.
-          example: ""
+          example: '0x5368c0c1ee386222966ceca9a0029be32527959b9fd2a8a6d61388bcee6d66c1'
         signature:
           type: string
-          descripition: The signature.
-          example: ""
+          description: The signature.
+          example: '0x8e78a5e701e530365594aefb43a3219b6aa8bea214425847c654797a46ce1967528d2e6714f469ca308ee96a08319a4135fdc84923c04f784de414a840e4020e'
       required:
         - type
         - publicKey
         - signature
-
     OutputMetadata:
       description: Metadata of an output.
       properties:
         blockId:
           type: string
           description: The ID of the block.
-          example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          example: '0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85'
         transactionId:
           type: string
           description: The ID of the transaction which created this output.
-          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+          example: '0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7'
         outputIndex:
           type: number
           description: The index of the output within its transaction.
-
           example: 0
         isSpent:
           type: boolean
@@ -1075,19 +1202,25 @@ components:
           example: 242412
         milestoneTimestampSpent:
           type: number
-          description: The UNIX timestamp in seconds of the milestone at which the output was spent.
+          description: >-
+            The UNIX timestamp in seconds of the milestone at which the output
+            was spent.
           example: 1609950538
         transactionIdSpent:
           type: string
           description: The transaction this output was spent with.
-          example: "0xe526f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+          example: '0xe526f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7'
         milestoneIndexBooked:
           type: number
-          description: The index of the milestone at which the output was booked in the ledger.
+          description: >-
+            The index of the milestone at which the output was booked in the
+            ledger.
           example: 242412
         milestoneTimestampBooked:
           type: number
-          description: The UNIX timestamp in seconds of the milestone at which the output was booked in the ledger.
+          description: >-
+            The UNIX timestamp in seconds of the milestone at which the output
+            was booked in the ledger.
           example: 1609950538
         ledgerIndex:
           type: number

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -995,20 +995,23 @@ components:
       properties:
         type:
           type: number
-          description: The type of the MilestoneOptProtocolParams (1).
+          description: The type of the ProtocolParamsMilestoneOptions (1).
           example: 1
-        nextPoWScore:
-          type: number
-          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
-          example: 2000.0
-        nextPoWScoreMilestoneIndex:
-          type: number
-          description: The milestone index at which the PoW score changes to NextPoWScore.
+        targetMilestoneIndex:
+          type: integer
+          description: The milestone index at which these protocol parameters become active.
+        protocolVersion:
+          type: integer
+          description: The to be applied protocol version.
+        params:
+          type: string
+          description: The protocol parameters in binary form. Hex-encoded with 0x prefix.
           example: 150
       required:
         - type
-        - nextPowScore
-        - nextPoWScoreMilestoneIndex
+        - targetMilestoneIndex
+        - protocolVersion
+        - params
 
     Ed25519Signature:
       description: Ed25519Signature defines an Ed25519 signature.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -442,6 +442,30 @@ components:
             type: string
             description: The inclusion state of the block.
             enum: [ noTransaction, conflicting, included ]
+            example: conflicting
+          conflictReason:
+            type: integer
+            enum: [ 1,2,3,4,5,6,7,8,9,10,11,12,255 ]
+            description: >
+              Values:
+                * `1` - denotes that the referenced UTXO was already spent.
+                * `2` - denotes that the referenced UTXO was already spent while confirming this milestone.
+                * `3` - denotes that the referenced UTXO cannot be found.
+                * `4` - denotes that the sum of the inputs and output values does not match.
+                * `5` - denotes that the unlock block signature is invalid.
+                * `6` - denotes that the configured timelock is not yet expired.
+                * `7` - denotes that the given native tokens are invalid.
+                * `8` - denotes that the return amount in a transaction is not fulfilled by the output side.
+                * `9` - denotes that the input unlock is invalid.
+                * `10` - denotes that the inputs commitment is invalid.
+                * `11` - denotes that an output contains a Sender with an ident (address) which is not unlocked.
+                * `12` - denotes that the chain state transition is invalid.
+                * `255` - denotes that the semantic validation failed.
+            example: 1
+          whiteFlagIndex:
+            type: integer
+            description: If set, defines the order of the block in the white flag traversal during milestone solidification. Only referenced blocks have this information.
+            example: 13
           shouldPromote:
             type: boolean
             description: Whether the block should be promoted. This is determined automatically by the node by using the OCRI/YCRI of the block.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -544,7 +544,8 @@ components:
         - type
         - address
     StorageDepositReturnUnlockCondition:
-      description: Can be unlocked by depositting return amount to return address via an output that only has Address Unlock Condition.
+      description: Can be unlocked by depositing return amount to return address via an output that only has Address Unlock Condition.
+
       properties:
         type:
           type: integer

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -341,8 +341,7 @@ components:
       payload:
         type: object
         required:
-          - "index"
-          - "timestamp"
+          - "milestoneIndex"
         properties:
           milestoneIndex:
             type: number

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -158,13 +158,12 @@ channels:
       message:
         $ref: '#/components/messages/OutputPayload'
   outputs/aliases/{aliasId}:
-
     parameters:
       aliasId:
         description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
         schema:
           type: string
-          example: "0x6457f5f1bc2c3ec696889309cee0665c298f6394"
+          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
     subscribe:
       tags:
         - name: outputs
@@ -178,7 +177,7 @@ channels:
         description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
         schema:
           type: string
-          example: "0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd"
+          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
     subscribe:
       tags:
         - name: outputs
@@ -192,7 +191,7 @@ channels:
         description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.
         schema:
           type: string
-          example: "0x0868cebac478305970c1be92c4b4c54f7dc5eb3e790100000000"
+          example: "0x081505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d60100000000"
     subscribe:
       tags:
         - name: outputs
@@ -495,7 +494,7 @@ components:
         tokenId:
           type: string
           description: Hex-encoded identifier of the native token.
-          example: "0x086f5e13ae5394ca69f921d4da29a5aeabb642bd040100000000000000000000000000000000"
+          example: "0x08de3fa7acc30ec899bb797b1d80680690b54a1cdb78b2f7f50b1ad073e74c8cbd0100000000000000000000000000000000"
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex encoded number.
@@ -526,8 +525,8 @@ components:
           example: 1
         aliasId:
           type: string
-          description: The hex-encoded BLAKE2b-160 hash of the outputId that created the alias.
-          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+          description: The hex-encoded BLAKE2b-256 hash of the outputId that created the alias.
+          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
       required:
         - type
         - aliasId
@@ -540,8 +539,8 @@ components:
           example: 1
         nftId:
           type: string
-          description: The hex-encoded BLAKE2b-160 hash of the outputId that created the NFT.
-          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+          description: The hex-encoded BLAKE2b-256 hash of the outputId that created the NFT.
+          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
       required:
         - type
         - nftId
@@ -807,9 +806,9 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         aliasId:
           type: string
-          description: Unique identifier of the alias, which is the BLAKE2b-160 hash of the Output ID that created it.
+          description: Unique identifier of the alias, which is the BLAKE2b-256 hash of the Output ID that created it.
             Alias Address = Alias Address Type || Alias ID
-          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+          example: "0x1505ec099896ab05d9e08fbc7101ae4dff0093b3943b28f789ed2ca728bcc8d6"
         stateIndex:
           type: integer
           description: A counter that must increase by 1 every time the alias is state transitioned.
@@ -926,8 +925,8 @@ components:
               - $ref: '#/components/schemas/NativeToken'
         nftId:
           type: string
-          description: Unique identifier of the NFT, which is the BLAKE2b-160 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID
-          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+          description: Unique identifier of the NFT, which is the BLAKE2b-256 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID
+          example: "0x19c82b32761fd8729a1a6c77f7c17597e4b9b01759794e52381f6a0050b0c11f"
         unlockConditions:
           type: array
           description: Unlock condtions that define how the output an be unlocked in a transaction.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -9,16 +9,22 @@ externalDocs:
   description: Find out more about IOTA
   url: 'https://iota.org'
 channels:
-  milestones/latest:
+  milestone-index/latest:
     subscribe:
-      operationId: milestoneLatest
-      description: Publishes the newest latest known milestone.
+      operationId: milestoneIndexLatest
+      description: Publishes the newest latest known milestone index and its timestamp.
       message:
-        $ref: '#/components/messages/MilestonePayload'
-  milestones/confirmed:
+        $ref: '#/components/messages/MilestoneIndexResponse'
+  milestone-index/confirmed:
     subscribe:
-      operationId: milestoneConfirmed
-      description: Publishes the newly confirmed milestone.
+      operationId: milestoneIndexConfirmed
+      description: Publishes the newly confirmed milestone index and its timestamp.
+      message:
+        $ref: '#/components/messages/MilestoneIndexResponse'
+  milestones:
+    subscribe:
+      operationId: milestones
+      description: Publishes newly created milestone payloads.
       message:
         $ref: '#/components/messages/MilestonePayload'
   messages:
@@ -198,7 +204,7 @@ channels:
 
 components:
   messages:
-    MilestonePayload:
+    MilestoneMetadata:
       contentType: application/json
       payload:
         type: object
@@ -214,6 +220,83 @@ components:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
+    MilestonePayload:
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - "type"
+          - "index"
+          - "timestamp"
+          - "lastMilestone"
+          - "parentMessageIds"
+          - "pastConeMerkleProof"
+          - "inclusionMerkleProof"
+          - "signatures"
+        properties:
+          type:
+            type: number
+            description: Payload type of the milestone.
+            example: 7
+          index:
+            type: number
+            description: The index of the milestone.
+            example: 242412
+          timestamp:
+            type: number
+            description: The UNIX timestamp in seconds of the milestone.
+            example: 1609950538
+          lastMilestone:
+            type: string
+            description: Milestone ID of the latest milestone. Hex-encoded with 0x prefix.
+            example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"
+          parentMessageIds:
+            type: array
+            description: The parents where this milestone attaches to
+            example:
+              - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+              - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          pastConeMerkleProof:
+            type: string
+            description: The merkle root of all directly/indirectly referenced messages (their IDs) which were newly confirmed by this milestone.
+            example: "0x014e3a82d54c1bf4e411eee30ce25ee739b0f790fca248c0036d538952d6072b"
+          inclusionMerkleProof:
+            type: string
+            description: The merkle root of all messages (their IDs) carrying ledger state mutating transactions.
+            example: "0x07fbcf40a98cf1e1e1e0aeb7527ecf464cc8d461f617e48931c6a2096cb18d1a"
+          metadata:
+            type: string
+            descripiton: The metadata associated with this milestone.
+            example: "0x01"
+          options:
+            type: array
+            items:
+             anyOf:
+               - $ref: '#/components/schemas/ReceiptMilestoneOpt'
+               - $ref: '#/components/schemas/ProtocolParamsMilestoneOptions'
+          signatures:
+            type: array
+            items:
+              anyOf:
+                - $ref: '#/components/schemas/Ed25519Signature'
+
+    MilestoneIndexResponse:
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - "index"
+          - "timestamp"
+        properties:
+          index:
+            type: number
+            description: The index of the milestone.
+            example: 242412
+          timestamp:
+            type: number
+            description: The UNIX timestamp in seconds of the milestone.
+            example: 1609950538
+
     Message:
       contentType: application/octet-stream
       description: The message in its serialized binary form.
@@ -793,3 +876,120 @@ components:
         - type
         - amount
         - unlockConditions
+
+    TreasuryInput:
+      properties:
+        type:
+          type: integer
+          description: Set to value 1 to denote a TreasuryInput.
+        milestoneId:
+          type: string
+          description: Hex-encoded with 0x prefix.
+      required:
+        - type
+        - milestoneId
+
+    TreasuryOutput:
+      properties:
+        type:
+          type: integer
+          description: Set to value 2 to denote a TreasuryOutput.
+        amount:
+          type: string
+          description: Amountt of IOTA tokens in the treasury. Plain string encoded number.
+      required:
+        - type
+        - amount
+
+    TreasuryTransactionPayload:
+      properties:
+        type:
+          type: integer
+          description: Set to value 4 to denote a Treasury Payload.
+        input:
+          allOf:
+            - $ref: '#/components/schemas/TreasuryInput'
+        output:
+          allOf:
+            - $ref: '#/components/schemas/TreasuryOutput'
+      required:
+        - type
+        - input
+        - output
+
+    MigratedFundsEntry:
+      properties:
+        tailTransactionHash:
+          type: string
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+        deposit:
+          type: integer
+      required:
+        - tailTransactionHash
+        - address
+        - deposit
+
+    ReceiptMilestoneOpt:
+      description: Contains a receipt and the index of the milestone which contained the receipt.
+      properties:
+        type:
+          type: integer
+          description: Type identifier of a receipt milestone option (0).
+        migratedAt:
+          type: integer
+        final:
+          type: boolean
+        funds:
+          type: array
+          items:
+            $ref: '#/components/schemas/MigratedFundsEntry'
+        transaction:
+          $ref: '#/components/schemas/TreasuryTransactionPayload'
+      required:
+        - migratedAt
+        - final
+        - funds
+        - transaction
+        - type
+
+    ProtocolParamsMilestoneOptions:
+      description: Defines changing protocol parameters.
+      properties:
+        type:
+          type: number
+          description: The type of the MilestoneOptProtocolParams (1).
+          example: 1
+        nextPoWScore:
+          type: number
+          description: The next minimum PoW score to use after NextPoWScoreMilestoneIndex is hit.
+          example: 2000.0
+        nextPoWScoreMilestoneIndex:
+          type: number
+          description: The milestone index at which the PoW score changes to NextPoWScore.
+          example: 150
+      required:
+        - type
+        - nextPowScore
+        - nextPoWScoreMilestoneIndex
+
+    Ed25519Signature:
+      description: Ed25519Signature defines an Ed25519 signature.
+      properties:
+        type:
+          type: number
+          description: Defines the type for an Ed255199Signature (0).
+          example: 0
+        publicKey:
+          type: string
+          description: The public key used to verify the given signature.
+          example: ""
+        signature:
+          type: string
+          descripition: The signature.
+          example: ""
+      required:
+        - type
+        - publicKey
+        - signature

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -902,7 +902,8 @@ components:
               - $ref: '#/components/schemas/TagFeature'
         immutableFeatures:
           type: array
-          description: Immutable featuressssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss that add utility to the output but do not impose unlocking conditions.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
+
             These blocks need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -107,7 +107,7 @@ channels:
       description: Publishes newly received messages which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data messages do not get published.
       message:
         $ref: '#/components/messages/Message'
-  messages-metadata/{messageId}:
+  message-metadata/{messageId}:
     parameters:
       messageId:
         description: Hex encoded identifier of the message.
@@ -117,15 +117,15 @@ channels:
     subscribe:
       tags:
         - name: messages
-      operationId: messagesSpecificMetadata
+      operationId: messageSpecificMetadata
       description: Publishes metadata of a particular message whenever its metadata changes.
       message:
         $ref: '#/components/messages/MessageMetadata'
-  messages-metadata/referenced:
+  message-metadata/referenced:
     subscribe:
       tags:
         - name: messages
-      operationId: messagesMetadataReferenced
+      operationId: messageMetadataReferenced
       description: Publishes metadata of a message whenever it gets referenced.
       message:
         $ref: '#/components/messages/MessageMetadata'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -848,7 +848,8 @@ components:
               - $ref: '#/components/schemas/SimpleTokenScheme'
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          description: Unlock condtions that define how the output can be unlocked in a transaction.
+
           items:
             anyOf:
               - $ref: '#/components/schemas/ImmutableAliasAddressUnlockCondition'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -873,7 +873,8 @@ components:
         - tokenScheme
         - unlockConditions
     NFTOutput:
-      description: escribes an NFT output, a globally unique token with metadata attached.
+      description: Describes an NFT output, a globally unique token with metadata attached.
+
       properties:
         type:
           type: integer

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -549,7 +549,8 @@ components:
       properties:
         type:
           type: integer
-          description: Set to value 1 to denote an Storage Deposit Return Unlock Condition.
+          description: Set to value 1 to denote a Storage Deposit Return Unlock Condition.
+
           example: 1
         returnAddress:
           oneOf:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -558,26 +558,22 @@ components:
         - returnAddress
         - returnAmount
     TimelockUnlockCondition:
-      description: Can be unlocked if the confirming milestone has a >= Milestone Index/Unixt Timestamp.
+      description: Can be unlocked if the confirming milestone has a >= Unix Timestamp.
       properties:
         type:
           type: integer
           description: Set to value 2 to denote an Timelock Unlock Condition.
           example: 2
-        milestoneIndex:
-          type: integer
-          description: The milestone index starting from which the output can be consumed.
-          example: 1246873
         unixTime:
           type: integer
           description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
           example: 1609950538
+          exclusiveMinimum: 0
       required:
         - type
-        - milestoneIndex
         - unixTime
     ExpirationUnlockCondition:
-      description: Defines a milestone index and/or unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the milestone index and/or unix time, only Return Address can unlock it.
+      description: Defines a unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the unix time, only Return Address can unlock it.
       properties:
         type:
           type: integer
@@ -588,18 +584,14 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
-        milestoneIndex:
-          type: integer
-          description: Before this milestone index, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
-          example: 1246873
         unixTime:
           type: integer
           description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
           example: 1609950538
+          exclusiveMinimum: 0
       required:
         - type
         - returnAddress
-        - milestoneIndex
         - unixTime
     StateControllerAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -158,6 +158,7 @@ channels:
     subscribe:
       tags:
         - name: transactions
+        - name: blocks
       operationId: transactionIncludedBlock
       description: >-
         Publishes the confirmed block which carried the transaction with the

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -735,7 +735,8 @@ components:
                - $ref: '#/components/schemas/NativeToken'
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          description: Unlock condtions that define how the output can be unlocked in a transaction.
+
           items:
             anyOf:
               - $ref: '#/components/schemas/AddressUnlockCondition'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -289,7 +289,7 @@ components:
           - "index"
           - "timestamp"
           - "previousMilestoneId"
-          - "parentBlockIds"
+          - "parents"
           - "pastConeMerkleProof"
           - "inclusionMerkleProof"
           - "signatures"
@@ -310,7 +310,7 @@ components:
             type: string
             description: Milestone ID of the previous milestone (index - 1). Hex-encoded with 0x prefix.
             example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"
-          parentBlockIds:
+          parents:
             type: array
             description: The parents where this milestone attaches to
             example:
@@ -413,14 +413,14 @@ components:
         type: object
         required:
           - "blockId"
-          - "parentBlockIds"
+          - "parents"
           - "isSolid"
         properties:
           blockId:
             type: string
             description: The ID of the block.
             example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
-          parentBlockIds:
+          parents:
             type: array
             description: The IDs of the referenced parent blocks.
             example:
@@ -627,12 +627,12 @@ components:
       required:
         - type
         - address
-    SenderBlock:
+    SenderFeature:
       description: Identifies the validated sender of the output.
       properties:
         type:
           type: integer
-          description: Set to value 0 to denote a Sender Block.
+          description: Set to value 0 to denote a Sender Feature.
           example: 0
         sender:
           oneOf:
@@ -642,12 +642,12 @@ components:
       required:
         - type
         - sender
-    IssuerBlock:
+    IssuerFeature:
       description: Identifies the validated issuer of the UTXO state machine (alias/NFT).
       properties:
         type:
           type: integer
-          description: Set to value 1 to denote an Issuer Block.
+          description: Set to value 1 to denote an Issuer Feature.
           example: 1
         issuer:
           oneOf:
@@ -657,12 +657,12 @@ components:
       required:
         - type
         - issuer
-    MetadataBlock:
+    MetadataFeature:
       description: Defines metadata (arbitrary binary data) that will be stored in the output.
       properties:
         type:
           type: integer
-          description: Set to value 2 to denote a Metadata Block.
+          description: Set to value 2 to denote a Metadata Feature.
           example: 2
         data:
           type: string
@@ -671,12 +671,12 @@ components:
       required:
         - type
         - data
-    TagBlock:
+    TagFeature:
       description: Defines an indexation tag to which the output can be indexed by additional node plugins.
       properties:
         type:
           type: integer
-          description: Set to value 3 to denote a Metadata Block.
+          description: Set to value 3 to denote a Tag Feature.
           example: 3
         tag:
           type: string
@@ -735,14 +735,14 @@ components:
               - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
               - $ref: '#/components/schemas/TimelockUnlockCondition'
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-              - $ref: '#/components/schemas/TagBlock'
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+              - $ref: '#/components/schemas/TagFeature'
       required:
        - type
        - amount
@@ -788,21 +788,21 @@ components:
             anyOf:
               - $ref: '#/components/schemas/StateControllerAddressUnlockCondition'
               - $ref: '#/components/schemas/GovernorAddressUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
             These blocks need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount
@@ -843,19 +843,19 @@ components:
           items:
             anyOf:
               - $ref: '#/components/schemas/ImmutableAliasAddressUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/MetadataBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/MetadataFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Immutable features that add utility to the output but do not impose unlocking conditions.
             These blocks need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount
@@ -891,23 +891,23 @@ components:
               - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
               - $ref: '#/components/schemas/TimelockUnlockCondition'
               - $ref: '#/components/schemas/ExpirationUnlockCondition'
-        featureBlocks:
+        features:
           type: array
-          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Features that add utility to the output but do not impose unlocking conditions.
           items:
             anyOf:
-              - $ref: '#/components/schemas/SenderBlock'
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
-              - $ref: '#/components/schemas/TagBlock'
-        immutableFeatureBlocks:
+              - $ref: '#/components/schemas/SenderFeature'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
+              - $ref: '#/components/schemas/TagFeature'
+        immutableFeatures:
           type: array
-          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+          description: Immutable featuressssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss that add utility to the output but do not impose unlocking conditions.
             These blocks need to be kept in future transitions of the UTXO state machine.
           items:
             anyOf:
-              - $ref: '#/components/schemas/IssuerBlock'
-              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/IssuerFeature'
+              - $ref: '#/components/schemas/MetadataFeature'
       required:
         - type
         - amount

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -11,8 +11,8 @@ externalDocs:
 tags:
   - name: milestones
     description: Everything about milestones.
-  - name: messages
-    description: Everything about messages.
+  - name: blocks
+    description: Everything about blocks.
   - name: outputs
     description: Everything about outputs.
   - name: transactions
@@ -44,33 +44,33 @@ channels:
       description: Publishes newly created milestone payloads.
       message:
         $ref: '#/components/messages/MilestonePayloadSerialized'
-  messages:
+  blocks:
     subscribe:
       tags:
-        - name: messages
-      operationId: messages
-      description: Publishes newly received messages in their serialized binary form.
+        - name: blocks
+      operationId: blocks
+      description: Publishes newly received blocks in their serialized binary form.
       message:
-        $ref: '#/components/messages/Message'
-  messages/transaction:
+        $ref: '#/components/messages/Block'
+  blocks/transaction:
     subscribe:
       tags:
-        - name: messages
+        - name: blocks
         - name: transactions
-      operationId: messagesTransaction
-      description: Publishes newly received messages containing a transaction payload in their serialized binary form.
+      operationId: blocksTransaction
+      description: Publishes newly received blocks containing a transaction payload in their serialized binary form.
       message:
-        $ref: '#/components/messages/Message'
-  messages/transaction/tagged-data:
+        $ref: '#/components/messages/Block'
+  blocks/transaction/tagged-data:
     subscribe:
       tags:
-        - name: messages
+        - name: blocks
         - name: transactions
-      operationId: messagesTransactionsWithTaggedData
-      description: Publishes newly received messages containing a Tagged Data payload inside transactions.
+      operationId: blocksTransactionsWithTaggedData
+      description: Publishes newly received blocks containing a Tagged Data payload inside transactions.
       message:
-        $ref: '#/components/messages/Message'
-  messages/transaction/tagged-data/{tag}:
+        $ref: '#/components/messages/Block'
+  blocks/transaction/tagged-data/{tag}:
     parameters:
       tag:
         description: Hex encoded tag of the Tagged Data Payload inside the Transaction Payload.
@@ -79,21 +79,21 @@ channels:
           example: "0xe45"
     subscribe:
       tags:
-        - name: messages
+        - name: blocks
         - name: transactions
-      operationId: messagesTransactionsWithTag
-      description: Publishes newly received messages containing a Tagged Data payload inside transactions with a specific tag.
+      operationId: blocksTransactionsWithTag
+      description: Publishes newly received blocks containing a Tagged Data payload inside transactions with a specific tag.
       message:
-        $ref: '#/components/messages/Message'
-  messages/tagged-data:
+        $ref: '#/components/messages/Block'
+  blocks/tagged-data:
     subscribe:
       tags:
-        - name: messages
-      operationId: messagesWithTaggedData
-      description: Publishes newly received messages which contain tagged data payloads (encoded in hex) in their serialized binary form.
+        - name: blocks
+      operationId: blocksWithTaggedData
+      description: Publishes newly received blocks which contain tagged data payloads (encoded in hex) in their serialized binary form.
       message:
-        $ref: '#/components/messages/Message'
-  messages/tagged-data/{tag}:
+        $ref: '#/components/messages/Block'
+  blocks/tagged-data/{tag}:
     parameters:
       tag:
         description: Hex encoded tag of the Tagged Data Payload.
@@ -102,34 +102,34 @@ channels:
           example: "0xe45"
     subscribe:
       tags:
-        - name: messages
-      operationId: messagesWithSpecificTag
-      description: Publishes newly received messages which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data messages do not get published.
+        - name: blocks
+      operationId: blocksWithSpecificTag
+      description: Publishes newly received blocks which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data blocks do not get published.
       message:
-        $ref: '#/components/messages/Message'
-  message-metadata/{messageId}:
+        $ref: '#/components/messages/Block'
+  block-metadata/{blockId}:
     parameters:
-      messageId:
-        description: Hex encoded identifier of the message.
+      blockId:
+        description: Hex encoded identifier of the block.
         schema:
           type: string
           example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
     subscribe:
       tags:
-        - name: messages
-      operationId: messageSpecificMetadata
-      description: Publishes metadata of a particular message whenever its metadata changes.
+        - name: blocks
+      operationId: blockSpecificMetadata
+      description: Publishes metadata of a particular block whenever its metadata changes.
       message:
-        $ref: '#/components/messages/MessageMetadata'
-  message-metadata/referenced:
+        $ref: '#/components/messages/BlockMetadata'
+  block-metadata/referenced:
     subscribe:
       tags:
-        - name: messages
-      operationId: messageMetadataReferenced
-      description: Publishes metadata of a message whenever it gets referenced.
+        - name: blocks
+      operationId: blockMetadataReferenced
+      description: Publishes metadata of a block whenever it gets referenced.
       message:
-        $ref: '#/components/messages/MessageMetadata'
-  transactions/{transactionId}/included-message:
+        $ref: '#/components/messages/BlockMetadata'
+  transactions/{transactionId}/included-block:
     parameters:
       transactionId:
         description: Hex encoded identifier of the transaction.
@@ -140,9 +140,9 @@ channels:
       tags:
         - name: transactions
       operationId: transactions
-      description: Publishes the confirmed message which carried the transaction with the specified transaction id.
+      description: Publishes the confirmed block which carried the transaction with the specified transaction id.
       message:
-        $ref: '#/components/messages/Message'
+        $ref: '#/components/messages/Block'
   outputs/{outputId}:
     parameters:
       outputId:
@@ -289,7 +289,7 @@ components:
           - "index"
           - "timestamp"
           - "previousMilestoneId"
-          - "parentMessageIds"
+          - "parentBlockIds"
           - "pastConeMerkleProof"
           - "inclusionMerkleProof"
           - "signatures"
@@ -310,7 +310,7 @@ components:
             type: string
             description: Milestone ID of the previous milestone (index - 1). Hex-encoded with 0x prefix.
             example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"
-          parentMessageIds:
+          parentBlockIds:
             type: array
             description: The parents where this milestone attaches to
             example:
@@ -318,11 +318,11 @@ components:
               - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
           pastConeMerkleProof:
             type: string
-            description: The merkle root of all directly/indirectly referenced messages (their IDs) which were newly confirmed by this milestone.
+            description: The merkle root of all directly/indirectly referenced blocks (their IDs) which were newly confirmed by this milestone.
             example: "0x014e3a82d54c1bf4e411eee30ce25ee739b0f790fca248c0036d538952d6072b"
           inclusionMerkleProof:
             type: string
-            description: The merkle root of all messages (their IDs) carrying ledger state mutating transactions.
+            description: The merkle root of all blocks (their IDs) carrying ledger state mutating transactions.
             example: "0x07fbcf40a98cf1e1e1e0aeb7527ecf464cc8d461f617e48931c6a2096cb18d1a"
           metadata:
             type: string
@@ -370,9 +370,9 @@ components:
             description: Hex encoded identifier of the milestone payload.
             example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
 
-    Message:
+    Block:
       contentType: application/octet-stream
-      description: The message in its serialized binary form.
+      description: The block in its serialized binary form.
       payload:
         type: string
         format: binary
@@ -407,44 +407,44 @@ components:
               - $ref: '#/components/schemas/AliasOutput'
               - $ref: '#/components/schemas/FoundryOutput'
               - $ref: '#/components/schemas/NFTOutput'
-    MessageMetadata:
+    BlockMetadata:
       contentType: application/json
       payload:
         type: object
         required:
-          - "messageId"
-          - "parentMessageIds"
+          - "blockId"
+          - "parentBlockIds"
           - "isSolid"
         properties:
-          messageId:
+          blockId:
             type: string
-            description: The ID of the message.
+            description: The ID of the block.
             example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
-          parentMessageIds:
+          parentBlockIds:
             type: array
-            description: The IDs of the referenced parent messages.
+            description: The IDs of the referenced parent blocks.
             example:
               - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
               - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
           isSolid:
             type: boolean
-            description: Whether the message is solid or not.
+            description: Whether the block is solid or not.
             example: true
           referencedByMilestoneIndex:
             type: number
-            description: The index of the milestone which referenced this message.
+            description: The index of the milestone which referenced this block.
             example: 242544
           ledgerInclusionState:
             type: string
-            description: The inclusion state of the message.
+            description: The inclusion state of the block.
             enum: [ noTransaction, conflicting, included ]
           shouldPromote:
             type: boolean
-            description: Whether the message should be promoted. This is determined automatically by the node by using the OCRI/YCRI of the message.
+            description: Whether the block should be promoted. This is determined automatically by the node by using the OCRI/YCRI of the block.
             example: true
           shouldReattach:
             type: boolean
-            description: Whether the message should be re-attached. This is determined automatically by the node by using the OCRI/YCRI of the message.
+            description: Whether the block should be re-attached. This is determined automatically by the node by using the OCRI/YCRI of the block.
             example: false
 
   schemas:
@@ -1033,9 +1033,9 @@ components:
     OutputMetadata:
       description: Metadata of an output.
       properties:
-        messageId:
+        blockId:
           type: string
-          description: The ID of the message.
+          description: The ID of the block.
           example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
         transactionId:
           type: string
@@ -1074,7 +1074,7 @@ components:
           description: The ledger index at which this output was available at.
           example: 100000
       required:
-        - messageId
+        - blockId
         - transactionId
         - outputIndex
         - isSpent

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -607,7 +607,8 @@ components:
       properties:
         type:
           type: integer
-          description: Set to value 4 to denote an  Sate Controller Address Unlock Condition.
+          description: Set to value 4 to denote a Sate Controller Address Unlock Condition.
+
           example: 4
         address:
           oneOf:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -493,8 +493,8 @@ components:
       properties:
         tokenId:
           type: string
-          description: Hex-encoded identifier of the native token.
-          example: "0x08de3fa7acc30ec899bb797b1d80680690b54a1cdb78b2f7f50b1ad073e74c8cbd0100000000000000000000000000000000"
+          description: Hex-encoded identifier of the native token that equals the foundryId of the controlling foundry.
+          example: "0x08de3fa7acc30ec899bb797b1d80680690b54a1cdb78b2f7f50b1ad073e74c8cbd0100000000"
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex encoded number.
@@ -871,10 +871,6 @@ components:
           type: integer
           description: The serial number of the foundry with respect to the controlling alias.
           example: 2
-        tokenTag:
-          type: string
-          description: Hex-encoded data that is always the last 12 bytes of ID of the tokens produced by this foundry.
-          example: "0x4c657669436f696e000000"
         tokenScheme:
           type: array
           description: Defines the supply control scheme of the tokens controlled by the foundry.
@@ -904,7 +900,6 @@ components:
         - type
         - amount
         - serialNumber
-        - tokenTag
         - tokenScheme
         - unlockConditions
     NFTOutput:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -263,23 +263,6 @@ channels:
 
 components:
   messages:
-    MilestoneMetadata:
-      contentType: application/json
-      payload:
-        type: object
-        required:
-          - "index"
-          - "timestamp"
-        properties:
-          index:
-            type: number
-            description: The index of the milestone.
-            example: 242412
-          timestamp:
-            type: number
-            description: The UNIX timestamp in seconds of the milestone.
-            example: 1609950538
-
     MilestonePayload:
       contentType: application/json
       payload:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -391,54 +391,14 @@ components:
       payload:
         type: object
         required:
-          - "messageId"
-          - "transactionId"
-          - "outputIndex"
-          - "isSpent"
-          - "milestoneIndexBooked"
-          - "milestoneTimestampBooked"
-          - "ledgerIndex"
+          - "metadata"
           - "output"
         properties:
-          messageId:
-            type: string
-            description: The ID of the message.
-            example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
-          transactionId:
-            type: string
-            description: The ID of the transaction which created this output.
-            example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
-          outputIndex:
-            type: number
-            description: The index of the this output within its transaction.
-            example: 0
-          isSpent:
-            type: boolean
-            description: Whether the output is spent or not.
-            example: true
-          milestoneIndexSpent:
-            type: number
-            description: The index of the milestone at which the output was spent.
-            example: 242412
-          milestoneTimestampSpent:
-            type: number
-            description: The UNIX timestamp in seconds of the milestone at which the output was spent.
-            example: 1609950538
-          transactionIdSpent:
-            type: string
-            description: The transaction this output was spent with.
-            example: "0xe526f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
-          milestoneIndexBooked:
-            type: number
-            description: The index of the milestone at which the output was booked in the ledger.
-            example: 242412
-          milestoneTimestampBooked:
-            type: number
-            description: The UNIX timestamp in seconds of the milestone at which the output was booked in the ledger.
-            example: 1609950538
-          ledgerIndex:
-            type: number
-            description: The ledger index at which this output was available at.
+          metadata:
+            type: object
+            description: Metadata about the output.
+            oneOf:
+              - $ref: '#/components/schemas/OutputMetadata'
           output:
             type: object
             description: The output object itself.
@@ -1069,3 +1029,55 @@ components:
         - type
         - publicKey
         - signature
+
+    OutputMetadata:
+      description: Metadata of an output.
+      properties:
+        messageId:
+          type: string
+          description: The ID of the message.
+          example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+        transactionId:
+          type: string
+          description: The ID of the transaction which created this output.
+          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+        outputIndex:
+          type: number
+          description: The index of the this output within its transaction.
+          example: 0
+        isSpent:
+          type: boolean
+          description: Whether the output is spent or not.
+          example: true
+        milestoneIndexSpent:
+          type: number
+          description: The index of the milestone at which the output was spent.
+          example: 242412
+        milestoneTimestampSpent:
+          type: number
+          description: The UNIX timestamp in seconds of the milestone at which the output was spent.
+          example: 1609950538
+        transactionIdSpent:
+          type: string
+          description: The transaction this output was spent with.
+          example: "0xe526f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+        milestoneIndexBooked:
+          type: number
+          description: The index of the milestone at which the output was booked in the ledger.
+          example: 242412
+        milestoneTimestampBooked:
+          type: number
+          description: The UNIX timestamp in seconds of the milestone at which the output was booked in the ledger.
+          example: 1609950538
+        ledgerIndex:
+          type: number
+          description: The ledger index at which this output was available at.
+          example: 100000
+      required:
+        - messageId
+        - transactionId
+        - outputIndex
+        - isSpent
+        - milestoneIndexBooked
+        - milestoneTimestampBooked
+        - ledgerIndex

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -791,7 +791,8 @@ components:
           example: 3
         unlockConditions:
           type: array
-          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          description: Unlock condtions that define how the output can be unlocked in a transaction.
+
           items:
             anyOf:
               - $ref: '#/components/schemas/StateControllerAddressUnlockCondition'

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -1,0 +1,715 @@
+asyncapi: 2.0.0
+info:
+  title: Node Event API
+  contact:
+    email: contact@iota.org
+  version: 1.0.0
+  description: The node event API is in charge of publishing information about events within the node software.
+externalDocs:
+  description: Find out more about IOTA
+  url: 'https://iota.org'
+channels:
+  milestones/latest:
+    subscribe:
+      operationId: milestoneLatest
+      description: Publishes the newest latest known milestone.
+      message:
+        $ref: '#/components/messages/MilestonePayload'
+  milestones/confirmed:
+    subscribe:
+      operationId: milestoneConfirmed
+      description: Publishes the newly confirmed milestone.
+      message:
+        $ref: '#/components/messages/MilestonePayload'
+  messages:
+    subscribe:
+      operationId: messages
+      description: Publishes newly received messages in their serialized binary form.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/referenced:
+    subscribe:
+      operationId: messagesReferenced
+      description: Publishes metadata of messages newly referenced by a milestone.
+      message:
+        $ref: '#/components/messages/MessageMetadata'
+  messages/transaction:
+    subscribe:
+      operationId: messagesTransaction
+      description: Publishes newly received messages containing a transaction payload in their serialized binary form.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/transaction/taggedData/{tag}:
+    parameters:
+      tag:
+        description: Hex encoded tag of the Tagged Data Payload inside the Transaction Payload.
+        schema:
+          type: string
+          example: "0xe45"
+    subscribe:
+      operationId: messagesTransactionsWithTag
+      description: Publishes newly received messages containing a tagged Data payload inside transactions with a specific tag.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/milestone:
+    subscribe:
+      operationId: messagesMilestone
+      description: Publishes newly received messages containing a milestone payload in their serialized binary form.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/taggedData/{tag}:
+    parameters:
+      tag:
+        description: Hex encoded tag of the Tagged Data Payload.
+        schema:
+          type: string
+          example: "0xe45"
+    subscribe:
+      operationId: messagesWithSpecificTag
+      description: Publishes newly received messages which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data messages do not get published.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/taggedData:
+    subscribe:
+      operationId: messagesWithTaggedData
+      description: Publishes newly received messages which contain tagged data payloads (encoded in hex) in their serialized binary form.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/{messageId}/metadata:
+    parameters:
+      messageId:
+        description: Hex encoded identifier of the message.
+        schema:
+          type: string
+          example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+    subscribe:
+      operationId: messagesSpecificMetadata
+      description: Publishes metadata of a particular message whenever its metadata changes.
+      message:
+        $ref: '#/components/messages/MessageMetadata'
+  transactions/{transactionId}/included-message:
+    parameters:
+      transactionId:
+        description: Hex encoded identifier of the transaction.
+        schema:
+          type: string
+          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+    subscribe:
+      operationId: transactions
+      description: Publishes the confirmed message which carried the transaction with the specified transaction id.
+      message:
+        $ref: '#/components/messages/Message'
+  outputs/{outputId}:
+    parameters:
+      outputId:
+        description: Hex encoded identifier of the output.
+        schema:
+          type: string
+          example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be70000"
+    subscribe:
+      operationId: output
+      description: Publishes the given wanted output on subscription and when its state changes (created, spent).
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/unlock/{condition}/{address}:
+    parameters:
+      condition:
+        description: Type of unlock condition of the output to look for.
+        schema:
+          type: string
+          enum:
+            - "address"
+            - "storageReturn"
+            - "expirationReturn"
+            - "stateController"
+            - "governor"
+            - "immutableAlias"
+            - "+"
+      address:
+        description: Bech32 encoded address.
+        schema:
+          type: string
+          example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
+    subscribe:
+      operationId: outputByUnlockAndAddress
+      description: Publishes newly created outputs that have a specific address in a specific unlock condition.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/unlock/{condition}/{address}/spent:
+    parameters:
+      condition:
+        description: Type of unlock condition of the output to look for.
+        schema:
+          type: string
+          enum:
+            - "address"
+            - "storageReturn"
+            - "expirationReturn"
+            - "stateController"
+            - "governor"
+            - "immutableAlias"
+            - "+"
+      address:
+        description: Bech32 encoded address.
+        schema:
+          type: string
+          example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
+    subscribe:
+      operationId: outputByUnlockAndAddressSpent
+      description: Publishes newly spent outputs that have a specific address in a specific unlock condition.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+components:
+  messages:
+    MilestonePayload:
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - "index"
+          - "timestamp"
+        properties:
+          index:
+            type: number
+            description: The index of the milestone.
+            example: 242412
+          timestamp:
+            type: number
+            description: The UNIX timestamp in seconds of the milestone.
+            example: 1609950538
+    Message:
+      contentType: application/octet-stream
+      description: The message in its serialized binary form.
+      payload:
+        type: string
+        format: binary
+        example: >-
+          0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
+    OutputPayload:
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - "messageId"
+          - "transactionId"
+          - "outputIndex"
+          - "isSpent"
+          - "milestoneIndexBooked"
+          - "milestoneTimestampBooked"
+          - "ledgerIndex"
+          - "output"
+        properties:
+          messageId:
+            type: string
+            description: The ID of the message.
+            example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          transactionId:
+            type: string
+            description: The ID of the transaction which created this output.
+            example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+          outputIndex:
+            type: number
+            description: The index of the this output within its transaction.
+            example: 0
+          isSpent:
+            type: boolean
+            description: Whether the output is spent or not.
+            example: true
+          milestoneIndexSpent:
+            type: number
+            description: The index of the milestone at which the output was spent.
+            example: 242412
+          milestoneTimestampSpent:
+            type: number
+            description: The UNIX timestamp in seconds of the milestone at which the output was spent.
+            example: 1609950538
+          transactionIdSpent:
+            type: string
+            description: The transaction this output was spent with.
+            example: "0xe526f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+          milestoneIndexBooked:
+            type: number
+            description: The index of the milestone at which the output was booked in the ledger.
+            example: 242412
+          milestoneTimestampBooked:
+            type: number
+            description: The UNIX timestamp in seconds of the milestone at which the output was booked in the ledger.
+            example: 1609950538
+          ledgerIndex:
+            type: number
+            description: The ledger index at which this output was available at.
+          output:
+            type: object
+            description: The output object itself.
+            anyOf:
+              - $ref: '#/components/schemas/BasicOutput'
+              - $ref: '#/components/schemas/AliasOutput'
+              - $ref: '#/components/schemas/FoundryOutput'
+              - $ref: '#/components/schemas/NFTOutput'
+    MessageMetadata:
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - "messageId"
+          - "parentMessageIds"
+          - "isSolid"
+        properties:
+          messageId:
+            type: string
+            description: The ID of the message.
+            example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          parentMessageIds:
+            type: array
+            description: The IDs of the referenced parent messages.
+            example:
+              - "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
+              - "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
+          isSolid:
+            type: boolean
+            description: Whether the message is solid or not.
+            example: true
+          referencedByMilestoneIndex:
+            type: number
+            description: The index of the milestone which referenced this message.
+            example: 242544
+          ledgerInclusionState:
+            type: string
+            description: The inclusion state of the message.
+            enum: [ noTransaction, conflicting, included ]
+          shouldPromote:
+            type: boolean
+            description: Whether the message should be promoted. This is determined automatically by the node by using the OCRI/YCRI of the message.
+            example: true
+          shouldReattach:
+            type: boolean
+            description: Whether the message should be re-attached. This is determined automatically by the node by using the OCRI/YCRI of the message.
+            example: false
+
+  schemas:
+    NativeToken:
+      description: A native token and its balance in the output.
+      properties:
+        tokenId:
+          type: string
+          description: Hex-encoded identifier of the native token.
+          example: "0x086f5e13ae5394ca69f921d4da29a5aeabb642bd040100000000000000000000000000000000"
+        amount:
+          type: string
+          description: Amount of native tokens (up to uint256). Hex encoded number.
+          example: "0xc8"
+    Ed25519Address:
+      description: The Ed25519 address.
+      properties:
+        type:
+          type: integer
+          description: Set to value 0 to denote an Ed25519 Address.
+          example: 0
+        pubKeyHash:
+          type: string
+          description: The hex-encoded BLAKE2b-256 hash of the Ed25519 public key.
+          example: "0x713c3e879b53398431f67312254101ffdd23067febc77f4949de57ee279c8bee"
+      required:
+        - type
+        - pubKeyHash
+    AliasAddress:
+      description: Address of an alias account.
+      properties:
+        type:
+          type: integer
+          description: Set to value 8 to denote an Alias Address.
+          example: 1
+        aliasId:
+          type: string
+          description: The hex-encoded BLAKE2b-160 hash of the outputId that created the alias.
+          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+      required:
+        - type
+        - aliasId
+    NFTAddress:
+      description: Address of an NFT account.
+      properties:
+        type:
+          type: integer
+          description: Set to value 16 to denote an NFT Address.
+          example: 1
+        nftId:
+          type: string
+          description: The hex-encoded BLAKE2b-160 hash of the outputId that created the NFT.
+          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+      required:
+        - type
+        - nftId
+    AddressUnlockCondition:
+      description: Can be unlocked by unlocking the address.
+      properties:
+        type:
+          type: integer
+          description: Set to value 0 to denote an Address Unlock Condition.
+          example: 0
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+    ImmutableAliasAddressUnlockCondition:
+      description: Can be unlocked by unlocking the permanent alias address.
+        The unlock condition has to be kept in future state transitions of the UTXO state machine.
+      properties:
+        type:
+          type: integer
+          description: Set to value 6 to denote an Immutable Alias Address Unlock Condition.
+          example: 6
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/AliasAddress'
+    StorageDepositReturnUnlockCondition:
+      description: Can be unlocked by depositting return amount to return address via an output that only has Address Unlock Condition.
+      properties:
+        type:
+          type: integer
+          description: Set to value 1 to denote an Storage Deposit Return Unlock Condition.
+          example: 1
+        returnAddress:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+        returnAmount:
+          type: integer
+          description: Amount of IOTA tokens the consuming transaction should deposit to the address defined in Return Address.
+          example: 50
+    TimelockUnlockCondition:
+      description: Can be unlocked if the confirming milestone has a >= Milestone Index/Unixt Timestamp.
+      properties:
+        type:
+          type: integer
+          description: Set to value 2 to denote an Timelock Unlock Condition.
+          example: 2
+        milestoneIndex:
+          type: integer
+          description: The milestone index starting from which the output can be consumed.
+          example: 1246873
+        unixTime:
+          type: integer
+          description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
+          example: 1609950538
+    ExpirationUnlockCondition:
+      description: Defines a milestone index and/or unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the milestone index and/or unix time, only Return Address can unlock it.
+      properties:
+        type:
+          type: integer
+          description: Set to value 3 to denote an Expiration Unlock Condition.
+          example: 3
+        returnAddress:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+        milestoneIndex:
+          type: integer
+          description: Before this milestone index, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
+          example: 1246873
+        unixTime:
+          type: integer
+          description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
+          example: 1609950538
+    StateControllerAddressUnlockCondition:
+      description: Can be unlocked by unlocking the address.
+      properties:
+        type:
+          type: integer
+          description: Set to value 4 to denote an  Sate Controller Address Unlock Condition.
+          example: 4
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+    GovernorAddressUnlockCondition:
+      description: Can be unlocked by unlocking the address.
+      properties:
+        type:
+          type: integer
+          description: Set to value 5 to denote an  Governor Address Unlock Condition.
+          example: 5
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+    SenderBlock:
+      description: Identifies the validated sender of the output.
+      properties:
+        type:
+          type: integer
+          description: Set to value 0 to denote a Sender Block.
+          example: 0
+        sender:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+    IssuerBlock:
+      description: Identifies the validated issuer of the UTXO state machine (alias/NFT).
+      properties:
+        type:
+          type: integer
+          description: Set to value 1 to denote an Issuer Block.
+          example: 1
+        sender:
+          oneOf:
+            - $ref: '#/components/schemas/Ed25519Address'
+            - $ref: '#/components/schemas/AliasAddress'
+            - $ref: '#/components/schemas/NFTAddress'
+    MetadataBlock:
+      description: Defines metadata (arbitrary binary data) that will be stored in the output.
+      properties:
+        type:
+          type: integer
+          description: Set to value 2 to denote a Metadata Block.
+          example: 2
+        data:
+          type: string
+          description: Hex-encoded binary data.
+          example: "0xfa0de75d225cca2799395e5fc340702fc7eac8"
+    TagBlock:
+      description: Defines an indexation tag to which the output can be indexed by additional node plugins.
+      properties:
+        type:
+          type: integer
+          description: Set to value 3 to denote a Metadata Block.
+          example: 3
+        tag:
+          type: string
+          description: Hex-encoded binary indexation tag.
+          example: "0xfa0de75"
+    SimpleTokenScheme:
+      description: Defines the simple supply control scheme of native tokens. Tokens can be minted by the foundry without additional restrictions as long as maximum supply is requested and circulating supply is not negative.
+      properties:
+        type:
+          type: integer
+          description: Set to value 0 to denote an Simple Token Scheme.
+          example: 0
+    BasicOutput:
+      description: Describes a basic output with optional features.
+      properties:
+        type:
+          type: integer
+          description: Set to value 3 to denote a Basic Output.
+          example: 3
+        amount:
+          type: string
+          description: The amount of IOTA tokens to deposit with this BasicOutput output. Encoded as plain string.
+          example: "100"
+        nativeTokens:
+           type: array
+           description: Native tokens held by the otuput.
+           items:
+             anyOf:
+               - $ref: '#/components/schemas/NativeToken'
+        unlockConditions:
+          type: array
+          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/AddressUnlockCondition'
+              - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
+              - $ref: '#/components/schemas/TimelockUnlockCondition'
+              - $ref: '#/components/schemas/ExpirationUnlockCondition'
+        featureBlocks:
+          type: array
+          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/SenderBlock'
+              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/TagBlock'
+      required:
+       - type
+       - amount
+       - unlockConditions
+    AliasOutput:
+      description: Describes an alias account in the ledger that can be controlled by the state and governance controllers.
+      properties:
+        type:
+          type: integer
+          description: Set to value 4 to denote an Alias Output.
+          example: 4
+        amount:
+          type: string
+          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
+          example: "100"
+        nativeTokens:
+          type: array
+          description: Native tokens held by the otuput.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/NativeToken'
+        aliasId:
+          type: string
+          description: Unique identifier of the alias, which is the BLAKE2b-160 hash of the Output ID that created it.
+            Alias Address = Alias Address Type || Alias ID
+          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+        stateIndex:
+          type: integer
+          description: A counter that must increase by 1 every time the alias is state transitioned.
+          example: 1337
+        stateMetadata:
+          type: string
+          description: Hex-encoded metadata that can only be changed by the state controller.
+          example: "0x7665727920696d706f7274616e74207374617465206d65746164617461"
+        foundryCounter:
+          type: integer
+          description: A counter that denotes the number of foundries created by this alias account.
+          example: 3
+        unlockConditions:
+          type: array
+          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/StateControllerAddressUnlockCondition'
+              - $ref: '#/components/schemas/GovernorAddressUnlockCondition'
+        featureBlocks:
+          type: array
+          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/SenderBlock'
+              - $ref: '#/components/schemas/MetadataBlock'
+        immutableFeatureBlocks:
+          type: array
+          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+            These blocks need to be kept in future transitions of the UTXO state machine.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/IssuerBlock'
+              - $ref: '#/components/schemas/MetadataBlock'
+      required:
+        - type
+        - amount
+        - aliasId
+        - stateIndex
+        - foundryCounter
+        - unlockConditions
+    FoundryOutput:
+      description: Describes a foundry output that is controlled by an alias.
+      properties:
+        type:
+          type: integer
+          description: Set to value 5 to denote a Foundry Output.
+          example: 5
+        amount:
+          type: string
+          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
+          example: "100"
+        nativeTokens:
+          type: array
+          description: Native tokens held by the otuput.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/NativeToken'
+        serialNumber:
+          type: integer
+          description: The serial number of the foundry with respect to the controlling alias.
+          example: 2
+        tokenTag:
+          type: string
+          description: Hex-encoded data that is always the last 12 bytes of ID of the tokens produced by this foundry.
+          example: "0x4c657669436f696e000000"
+        mintedSupply:
+          type: string
+          description: Minted supply of tokens controlled by this foundry. Hex encoded number.
+          example: "0x2710"
+        meltedSupply:
+          type: string
+          description: Melted tokens controlled by this foundry. Hex encoded number.
+          example: "0x1388"
+        maxSupply:
+          type: string
+          description: Maximum supply of tokens controlled by this foundry. Hex encoded number.
+          example: "0x186a0"
+        tokenScheme:
+          type: array
+          description: Defines the supply control scheme of the tokens controlled by the foundry.
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/SimpleTokenScheme'
+        unlockConditions:
+          type: array
+          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ImmutableAliasAddressUnlockCondition'
+        featureBlocks:
+          type: array
+          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/MetadataBlock'
+        immutableFeatureBlocks:
+          type: array
+          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+            These blocks need to be kept in future transitions of the UTXO state machine.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/MetadataBlock'
+      required:
+        - type
+        - amount
+        - serialNumber
+        - tokenTag
+        - circulatingSupply
+        - maxSupply
+        - tokenScheme
+        - unlockConditions
+    NFTOutput:
+      description: escribes an NFT output, a globally unique token with metadata attached.
+      properties:
+        type:
+          type: integer
+          description: Set to value 6 to denote a NFT Output.
+        amount:
+          type: string
+          description: The amount of IOTA tokens to deposit with this output. Encoded as plain string.
+          example: "100"
+        nativeTokens:
+          type: array
+          description: Native tokens held by the otuput.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/NativeToken'
+        nftId:
+          type: string
+          description: Unique identifier of the NFT, which is the BLAKE2b-160 hash of the Output ID that created it. NFT Address = NFT Address Type || NFT ID
+          example: "0x6f5e13ae5394ca69f921d4da29a5aeabb642bd04"
+        unlockConditions:
+          type: array
+          description: Unlock condtions that define how the output an be unlocked in a transaction.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/AddressUnlockCondition'
+              - $ref: '#/components/schemas/StorageDepositReturnUnlockCondition'
+              - $ref: '#/components/schemas/TimelockUnlockCondition'
+              - $ref: '#/components/schemas/ExpirationUnlockCondition'
+        featureBlocks:
+          type: array
+          description: Feature blocks that add utility to the output but do not impose unlocking conditions.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/SenderBlock'
+              - $ref: '#/components/schemas/IssuerBlock'
+              - $ref: '#/components/schemas/MetadataBlock'
+              - $ref: '#/components/schemas/TagBlock'
+        immutableFeatureBlocks:
+          type: array
+          description: Immutable feature blocks that add utility to the output but do not impose unlocking conditions.
+            These blocks need to be kept in future transitions of the UTXO state machine.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/IssuerBlock'
+              - $ref: '#/components/schemas/MetadataBlock'
+      required:
+        - type
+        - amount
+        - unlockConditions

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -298,6 +298,9 @@ components:
           type: string
           description: Amount of native tokens (up to uint256). Hex encoded number.
           example: "0xc8"
+      required:
+        - tokenId
+        - amount
     Ed25519Address:
       description: The Ed25519 address.
       properties:
@@ -352,6 +355,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
     ImmutableAliasAddressUnlockCondition:
       description: Can be unlocked by unlocking the permanent alias address.
         The unlock condition has to be kept in future state transitions of the UTXO state machine.
@@ -363,6 +369,9 @@ components:
         address:
           oneOf:
             - $ref: '#/components/schemas/AliasAddress'
+      required:
+        - type
+        - address
     StorageDepositReturnUnlockCondition:
       description: Can be unlocked by depositting return amount to return address via an output that only has Address Unlock Condition.
       properties:
@@ -379,6 +388,10 @@ components:
           type: integer
           description: Amount of IOTA tokens the consuming transaction should deposit to the address defined in Return Address.
           example: 50
+      required:
+        - type
+        - returnAddress
+        - returnAmount
     TimelockUnlockCondition:
       description: Can be unlocked if the confirming milestone has a >= Milestone Index/Unixt Timestamp.
       properties:
@@ -394,6 +407,10 @@ components:
           type: integer
           description: Unix time (seconds since Unix epoch) starting from which the output can be consumed.
           example: 1609950538
+      required:
+        - type
+        - milestoneIndex
+        - unixTime
     ExpirationUnlockCondition:
       description: Defines a milestone index and/or unix time until which only Address, defined in Address Unlock Condition, is allowed to unlock the output. After the milestone index and/or unix time, only Return Address can unlock it.
       properties:
@@ -414,6 +431,11 @@ components:
           type: integer
           description: Before this unix time, Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address.
           example: 1609950538
+      required:
+        - type
+        - returnAddress
+        - milestoneIndex
+        - unixTime
     StateControllerAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.
       properties:
@@ -426,6 +448,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
     GovernorAddressUnlockCondition:
       description: Can be unlocked by unlocking the address.
       properties:
@@ -438,6 +463,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - address
     SenderBlock:
       description: Identifies the validated sender of the output.
       properties:
@@ -450,6 +478,9 @@ components:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - sender
     IssuerBlock:
       description: Identifies the validated issuer of the UTXO state machine (alias/NFT).
       properties:
@@ -457,11 +488,14 @@ components:
           type: integer
           description: Set to value 1 to denote an Issuer Block.
           example: 1
-        sender:
+        issuer:
           oneOf:
             - $ref: '#/components/schemas/Ed25519Address'
             - $ref: '#/components/schemas/AliasAddress'
             - $ref: '#/components/schemas/NFTAddress'
+      required:
+        - type
+        - issuer
     MetadataBlock:
       description: Defines metadata (arbitrary binary data) that will be stored in the output.
       properties:
@@ -473,6 +507,9 @@ components:
           type: string
           description: Hex-encoded binary data.
           example: "0xfa0de75d225cca2799395e5fc340702fc7eac8"
+      required:
+        - type
+        - data
     TagBlock:
       description: Defines an indexation tag to which the output can be indexed by additional node plugins.
       properties:
@@ -484,6 +521,9 @@ components:
           type: string
           description: Hex-encoded binary indexation tag.
           example: "0xfa0de75"
+      required:
+        - type
+        - tag
     SimpleTokenScheme:
       description: Defines the simple supply control scheme of native tokens. Tokens can be minted by the foundry without additional restrictions as long as maximum supply is requested and circulating supply is not negative.
       properties:
@@ -664,8 +704,6 @@ components:
         - amount
         - serialNumber
         - tokenTag
-        - circulatingSupply
-        - maxSupply
         - tokenScheme
         - unlockConditions
     NFTOutput:

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -289,7 +289,7 @@ components:
           - "type"
           - "index"
           - "timestamp"
-          - "lastMilestone"
+          - "lastMilestoneId"
           - "parentMessageIds"
           - "pastConeMerkleProof"
           - "inclusionMerkleProof"
@@ -307,7 +307,7 @@ components:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
-          lastMilestone:
+          lastMilestoneId:
             type: string
             description: Milestone ID of the latest milestone. Hex-encoded with 0x prefix.
             example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -491,6 +491,23 @@ components:
           type: integer
           description: Set to value 0 to denote an Simple Token Scheme.
           example: 0
+        mintedTokens:
+          type: string
+          description: Minted tokens controlled by this foundry. Hex encoded number.
+          example: "0x2710"
+        meltedTokens:
+          type: string
+          description: Melted tokens controlled by this foundry. Hex encoded number.
+          example: "0x1388"
+        maxSupply:
+          type: string
+          description: Maximum supply of tokens controlled by this foundry. Hex encoded number.
+          example: "0x186a0"
+      required:
+        - type
+        - mintedTokens
+        - meltedTokens
+        - maxSupply
     BasicOutput:
       description: Describes a basic output with optional features.
       properties:
@@ -617,18 +634,6 @@ components:
           type: string
           description: Hex-encoded data that is always the last 12 bytes of ID of the tokens produced by this foundry.
           example: "0x4c657669436f696e000000"
-        mintedSupply:
-          type: string
-          description: Minted supply of tokens controlled by this foundry. Hex encoded number.
-          example: "0x2710"
-        meltedSupply:
-          type: string
-          description: Melted tokens controlled by this foundry. Hex encoded number.
-          example: "0x1388"
-        maxSupply:
-          type: string
-          description: Maximum supply of tokens controlled by this foundry. Hex encoded number.
-          example: "0x186a0"
         tokenScheme:
           type: array
           description: Defines the supply control scheme of the tokens controlled by the foundry.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -39,7 +39,7 @@ channels:
       description: Publishes newly received messages containing a transaction payload in their serialized binary form.
       message:
         $ref: '#/components/messages/Message'
-  messages/transaction/taggedData/{tag}:
+  messages/transaction/tagged-data/{tag}:
     parameters:
       tag:
         description: Hex encoded tag of the Tagged Data Payload inside the Transaction Payload.
@@ -48,7 +48,7 @@ channels:
           example: "0xe45"
     subscribe:
       operationId: messagesTransactionsWithTag
-      description: Publishes newly received messages containing a tagged Data payload inside transactions with a specific tag.
+      description: Publishes newly received messages containing a Tagged Data payload inside transactions with a specific tag.
       message:
         $ref: '#/components/messages/Message'
   messages/milestone:
@@ -57,7 +57,7 @@ channels:
       description: Publishes newly received messages containing a milestone payload in their serialized binary form.
       message:
         $ref: '#/components/messages/Message'
-  messages/taggedData/{tag}:
+  messages/tagged-data/{tag}:
     parameters:
       tag:
         description: Hex encoded tag of the Tagged Data Payload.
@@ -69,7 +69,7 @@ channels:
       description: Publishes newly received messages which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data messages do not get published.
       message:
         $ref: '#/components/messages/Message'
-  messages/taggedData:
+  messages/tagged-data:
     subscribe:
       operationId: messagesWithTaggedData
       description: Publishes newly received messages which contain tagged data payloads (encoded in hex) in their serialized binary form.
@@ -119,11 +119,11 @@ channels:
           type: string
           enum:
             - "address"
-            - "storageReturn"
-            - "expirationReturn"
-            - "stateController"
+            - "storage-return"
+            - "expiration"
+            - "state-controller"
             - "governor"
-            - "immutableAlias"
+            - "immutable-alias"
             - "+"
       address:
         description: Bech32 encoded address.
@@ -143,11 +143,11 @@ channels:
           type: string
           enum:
             - "address"
-            - "storageReturn"
-            - "expirationReturn"
-            - "stateController"
+            - "storage-return"
+            - "expiration"
+            - "state-controller"
             - "governor"
-            - "immutableAlias"
+            - "immutable-alias"
             - "+"
       address:
         description: Bech32 encoded address.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -945,7 +945,8 @@ components:
           description: Set to value 2 to denote a TreasuryOutput.
         amount:
           type: string
-          description: Amountt of IOTA tokens in the treasury. Plain string encoded number.
+          description: Amount of IOTA tokens in the treasury. Plain string encoded number.
+
       required:
         - type
         - amount

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -3,46 +3,69 @@ info:
   title: Node Event API
   contact:
     email: contact@iota.org
-  version: 1.0.0
+  version: 2.0.0
   description: The node event API is in charge of publishing information about events within the node software.
 externalDocs:
   description: Find out more about IOTA
   url: 'https://iota.org'
+tags:
+  - name: milestones
+    description: Everything about milestones.
+  - name: messages
+    description: Everything about messages.
+  - name: outputs
+    description: Everything about outputs.
+  - name: transactions
+    description: Everything about transactions.
 channels:
-  milestone-index/latest:
+  milestone-info/latest:
     subscribe:
-      operationId: milestoneIndexLatest
+      operationId: milestoneInfoLatest
+      tags:
+        - name: milestones
       description: Publishes the newest latest known milestone index and its timestamp.
       message:
-        $ref: '#/components/messages/MilestoneIndexResponse'
-  milestone-index/confirmed:
+        $ref: '#/components/messages/MilestoneInfoResponse'
+  milestone-info/confirmed:
     subscribe:
-      operationId: milestoneIndexConfirmed
+      tags:
+        - name: milestones
+      operationId: milestoneInfoConfirmed
       description: Publishes the newly confirmed milestone index and its timestamp.
       message:
-        $ref: '#/components/messages/MilestoneIndexResponse'
+        $ref: '#/components/messages/MilestoneInfoResponse'
   milestones:
     subscribe:
+      tags:
+        - name: milestones
       operationId: milestones
       description: Publishes newly created milestone payloads.
       message:
-        $ref: '#/components/messages/MilestonePayload'
+        $ref: '#/components/messages/MilestonePayloadSerialized'
   messages:
     subscribe:
+      tags:
+        - name: messages
       operationId: messages
       description: Publishes newly received messages in their serialized binary form.
       message:
         $ref: '#/components/messages/Message'
-  messages/referenced:
-    subscribe:
-      operationId: messagesReferenced
-      description: Publishes metadata of messages newly referenced by a milestone.
-      message:
-        $ref: '#/components/messages/MessageMetadata'
   messages/transaction:
     subscribe:
+      tags:
+        - name: messages
+        - name: transactions
       operationId: messagesTransaction
       description: Publishes newly received messages containing a transaction payload in their serialized binary form.
+      message:
+        $ref: '#/components/messages/Message'
+  messages/transaction/tagged-data:
+    subscribe:
+      tags:
+        - name: messages
+        - name: transactions
+      operationId: messagesTransactionsWithTaggedData
+      description: Publishes newly received messages containing a Tagged Data payload inside transactions.
       message:
         $ref: '#/components/messages/Message'
   messages/transaction/tagged-data/{tag}:
@@ -53,14 +76,19 @@ channels:
           type: string
           example: "0xe45"
     subscribe:
+      tags:
+        - name: messages
+        - name: transactions
       operationId: messagesTransactionsWithTag
       description: Publishes newly received messages containing a Tagged Data payload inside transactions with a specific tag.
       message:
         $ref: '#/components/messages/Message'
-  messages/milestone:
+  messages/tagged-data:
     subscribe:
-      operationId: messagesMilestone
-      description: Publishes newly received messages containing a milestone payload in their serialized binary form.
+      tags:
+        - name: messages
+      operationId: messagesWithTaggedData
+      description: Publishes newly received messages which contain tagged data payloads (encoded in hex) in their serialized binary form.
       message:
         $ref: '#/components/messages/Message'
   messages/tagged-data/{tag}:
@@ -71,17 +99,13 @@ channels:
           type: string
           example: "0xe45"
     subscribe:
+      tags:
+        - name: messages
       operationId: messagesWithSpecificTag
       description: Publishes newly received messages which contain tagged data payloads with the specified tag parameter (encoded in hex) in their serialized binary form. Untagged data messages do not get published.
       message:
         $ref: '#/components/messages/Message'
-  messages/tagged-data:
-    subscribe:
-      operationId: messagesWithTaggedData
-      description: Publishes newly received messages which contain tagged data payloads (encoded in hex) in their serialized binary form.
-      message:
-        $ref: '#/components/messages/Message'
-  messages/{messageId}/metadata:
+  messages-metadata/{messageId}:
     parameters:
       messageId:
         description: Hex encoded identifier of the message.
@@ -89,8 +113,18 @@ channels:
           type: string
           example: "0xcf5f77d62285b9ed8d617729e9232ae346a328c1897f0939837198e93ec13e85"
     subscribe:
+      tags:
+        - name: messages
       operationId: messagesSpecificMetadata
       description: Publishes metadata of a particular message whenever its metadata changes.
+      message:
+        $ref: '#/components/messages/MessageMetadata'
+  messages-metadata/referenced:
+    subscribe:
+      tags:
+        - name: messages
+      operationId: messagesMetadataReferenced
+      description: Publishes metadata of a message whenever it gets referenced.
       message:
         $ref: '#/components/messages/MessageMetadata'
   transactions/{transactionId}/included-message:
@@ -101,6 +135,8 @@ channels:
           type: string
           example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be7"
     subscribe:
+      tags:
+        - name: transactions
       operationId: transactions
       description: Publishes the confirmed message which carried the transaction with the specified transaction id.
       message:
@@ -113,8 +149,53 @@ channels:
           type: string
           example: "0xd026f8b1c856d4e844cc734bbe095429fb880ec4d93f3ccffe3b292a7de17be70000"
     subscribe:
+      tags:
+        - name: outputs
       operationId: output
       description: Publishes the given wanted output on subscription and when its state changes (created, spent).
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/aliases/{aliasId}:
+
+    parameters:
+      aliasId:
+        description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x6457f5f1bc2c3ec696889309cee0665c298f6394"
+    subscribe:
+      tags:
+        - name: outputs
+      operationId: aliasOutputByAliasId
+      description: Publishes the newly created alias output of an alias chain.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/nfts/{nftId}:
+    parameters:
+      nftId:
+        description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd"
+    subscribe:
+      tags:
+        - name: outputs
+      operationId: nftOutputByNftId
+      description: Publishes the newly created nft output of an nft chain.
+      message:
+        $ref: '#/components/messages/OutputPayload'
+  outputs/foundries/{foundryId}:
+    parameters:
+      foundryId:
+        description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.
+        schema:
+          type: string
+          example: "0x0868cebac478305970c1be92c4b4c54f7dc5eb3e790100000000"
+    subscribe:
+      tags:
+        - name: outputs
+      operationId: foundryOutputByFoundryId
+      description: Publishes the newly created foundry output of a foundry chain.
       message:
         $ref: '#/components/messages/OutputPayload'
   outputs/unlock/{condition}/{address}:
@@ -137,6 +218,8 @@ channels:
           type: string
           example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
     subscribe:
+      tags:
+        - name: outputs
       operationId: outputByUnlockAndAddress
       description: Publishes newly created outputs that have a specific address in a specific unlock condition.
       message:
@@ -161,46 +244,13 @@ channels:
           type: string
           example: "iota1qrwfnskm4f7utdrxqnkfntfqxehtpj8s0kf68zkcwm0yrhuemzjp5sjfw5v"
     subscribe:
+      tags:
+        - name: outputs
       operationId: outputByUnlockAndAddressSpent
       description: Publishes newly spent outputs that have a specific address in a specific unlock condition.
       message:
         $ref: '#/components/messages/OutputPayload'
-  outputs/aliases/{aliasId}:
-    parameters:
-      aliasId:
-        description: The unique identifier of the alias chain. Hex encoded with 0x prefix.
-        schema:
-          type: string
-          example: "0x6457f5f1bc2c3ec696889309cee0665c298f6394"
-    subscribe:
-      operationId: aliasOutputByAliasId
-      description: Publishes the newly created alias output of an alias chain.
-      message:
-        $ref: '#/components/messages/OutputPayload'
-  outputs/nfts/{nftId}:
-    parameters:
-      nftId:
-        description: The unique identifier of the nft chain. Hex encoded with 0x prefix.
-        schema:
-          type: string
-          example: "0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd"
-    subscribe:
-      operationId: nftOutputByNftId
-      description: Publishes the newly created nft output of an nft chain.
-      message:
-        $ref: '#/components/messages/OutputPayload'
-  outputs/foundries/{foundryId}:
-    parameters:
-      foundryId:
-        description: The unique identifier of the foundry chain. Hex encoded with 0x prefix.
-        schema:
-          type: string
-          example: "0x0868cebac478305970c1be92c4b4c54f7dc5eb3e790100000000"
-    subscribe:
-      operationId: foundryOutputByFoundryId
-      description: Publishes the newly created foundry output of a foundry chain.
-      message:
-        $ref: '#/components/messages/OutputPayload'
+
 
 components:
   messages:
@@ -220,6 +270,7 @@ components:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
+
     MilestonePayload:
       contentType: application/json
       payload:
@@ -280,7 +331,16 @@ components:
               anyOf:
                 - $ref: '#/components/schemas/Ed25519Signature'
 
-    MilestoneIndexResponse:
+    MilestonePayloadSerialized:
+      contentType: application/octet-stream
+      description: The milestone payload in its serialized form.
+      payload:
+        type: string
+        format: binary
+        example: >-
+          070000000a1a0000977c626276b19ef8b3c445709f2f0f2ccc4abb98d97617f421f240c0d1ee066d4306e67a0321889ef8ec89b7eff1378049e058f0fa87a78c2452ae72631a5a99d913d1cbb3525b8faa1800e28dfcb28154bcba10154c39ef87ceda793cb44f58ae1549c88ea13fe4a9695bb6f0aba6cb756522209e5066a96039ae12b398b975693bdc21e222997c86ff9bfc5844f0372d58ff6fa510688e53c181bbdf4db41f9b627540a70e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a80000000300d85e5b1590d898d1e0cdebb2e3b5337c8b76270142663d78811683ba47c17c989ad7a8f0ff2c6438bf435786d4a5b0125a5caf7367061b49a739389d5ebea234c0466c86f88a3f8add03bff04c2e34b214683f2f6983641e1d1185da7e2c3e0200d9922819a39e94ddf3907f4b9c8df93f39f026244fcb609205b9a879022599f218be2536d8b7b8547faa3dbdfe98339ebe9e2b2417a8a03eee02b2a8312b9e026dd0a33261a58a240cd0a1b06cdf1775d98d316f162d3eec402f4bf08bea2a0700f9d9656a60049083eef61487632187b351294c1fa23d118060d813db6d03e8b6ca8180d435708e826bc2042ccd667babb59c5cc461ff29dba966359fcd6fc511cdfdf10d6576f36ac2a6e5cb691e13968c13947ffbd9239939d3802b2fbe0f06
+
+    MilestoneInfoResponse:
       contentType: application/json
       payload:
         type: object
@@ -288,14 +348,18 @@ components:
           - "index"
           - "timestamp"
         properties:
-          index:
+          milestoneIndex:
             type: number
             description: The index of the milestone.
             example: 242412
-          timestamp:
+          milestoneTimestamp:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
+          milestoneId:
+            type: string
+            description: Hex encoded identifier of the milestone payload.
+            example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
 
     Message:
       contentType: application/octet-stream

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -306,6 +306,10 @@ components:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
+          protocolVersion:
+            type: integer
+            description: Protocol version of the Milestone Payload and its encapsulating block.
+            example: 2
           previousMilestoneId:
             type: string
             description: Milestone ID of the previous milestone (index - 1). Hex-encoded with 0x prefix.

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -341,7 +341,7 @@ components:
                 - $ref: '#/components/schemas/Ed25519Signature'
 
     MilestonePayloadSerialized:
-      contentType: application/octet-stream
+      contentType: application/vnd.iota.serializer-v1
       description: The milestone payload in its serialized form.
       payload:
         type: string
@@ -371,7 +371,7 @@ components:
             example: "0x7a09324557e9200f39bf493fc8fd6ac43e9ca750c6f6d884cc72386ddcb7d695"
 
     Block:
-      contentType: application/octet-stream
+      contentType: application/vnd.iota.serializer-v1
       description: The block in its serialized binary form.
       payload:
         type: string
@@ -379,7 +379,7 @@ components:
         example: >-
           0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000eb000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000020000016920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92640000000000000000018afe1f314622cc1ef52f16d619d1baccff81816b7e4e35fe268dc247b730acd65d5d2dd3f7df09000000000001000001f7868ab6bb55800b77b8b74191ad8285a9bf428ace579d541fda47661803ff44e0af5c34ad4edf475a01fb46e089a7afcab158b4a0133f32e889083e1c77eef65548933e0c6d2c3b0ac006cd77e77d778bf37b8d38d219fb62a9a2f718d4c9095100000000000000
     Receipt:
-      contentType: application/octet-stream
+      contentType: application/vnd.iota.serializer-v1
       description: The migration receipts in its serialized binary form.
       payload:
         type: string

--- a/tips/TIP-0028/event-api.yml
+++ b/tips/TIP-0028/event-api.yml
@@ -289,7 +289,7 @@ components:
           - "type"
           - "index"
           - "timestamp"
-          - "lastMilestoneId"
+          - "previousMilestoneId"
           - "parentMessageIds"
           - "pastConeMerkleProof"
           - "inclusionMerkleProof"
@@ -307,9 +307,9 @@ components:
             type: number
             description: The UNIX timestamp in seconds of the milestone.
             example: 1609950538
-          lastMilestoneId:
+          previousMilestoneId:
             type: string
-            description: Milestone ID of the latest milestone. Hex-encoded with 0x prefix.
+            description: Milestone ID of the previous milestone (index - 1). Hex-encoded with 0x prefix.
             example: "0x4bd78256357630f186a4b302b3b8df7c01061260baa8d014f34187862343cf4e"
           parentMessageIds:
             type: array

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -3,7 +3,7 @@ tip: 28
 title: Event API
 description: Node event API definitions in AsyncAPI Specification
 author: Luca Moser (@luca-moser) <luca.moser@iota.org>, Levente Pap (@lzpap) <levente.pap@iota.org>
-discussions-to: https://github.com/iotaledger/tips/pull/33
+discussions-to: https://github.com/iotaledger/tips/pull/33, https://github.com/iotaledger/tips/pull/66
 status: Draft
 type: Standards
 layer: Interface

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -47,7 +47,7 @@ The access route of the message broker should be updated to:
 
 ## Reference Implementation
 
- - https://github.com/gohornet/hornet/tree/develop/tools/inx-mqtt
+ - https://github.com/gohornet/inx-mqtt
 
 ## Copyright
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -34,20 +34,29 @@ The API is described using the AsyncAPI Specification:
 
 ## Rationale
 
-TBW
+ - MQTT is a lightweight protocol that is good at minimizing bandwidth and ensuring message delivery via Quality of Service.
+ - It may run on resource constrained devices as well and works on top of TCP/IP protocol.
+ - The publish-subscribe model makes information dissemination effective to interested clients only.
 
 ## Backwards Compatibility
 
 The previously employed event API described in [TIP-16](../TIP-0016/tip-0016.md) is not backwards compatible with the
 current proposal, therefore versioning is introduced in the access URL of the API.
 
-Since the response models are shared between the REST API and the event API, this proposal implements API version `v2`.
+The response models are shared between the REST API and the event API.
+
 The access route of the message broker should be updated to:
- - `{nodeURL}/plugins/mqtt/v2`
+ - `{nodeURL}/api/mqtt/v1`
 
 ## Reference Implementation
 
+### Broker
  - https://github.com/gohornet/inx-mqtt
+
+### Client
+ - Go: https://github.com/iotaledger/iota.go/blob/develop/nodeclient/event_api_client.go
+ - Rust: https://github.com/iotaledger/iota.rs/tree/develop/src/node_api/mqtt
+ - TypeScript: https://github.com/iotaledger/iota.js/tree/feat/stardust/packages/mqtt
 
 ## Copyright
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -30,7 +30,7 @@ The event-based architecture should be of great benefit to:
 
 The API is described using the AsyncAPI Specification:
 
-[AsyncAPI Editor](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/iotaledger/tips/stardust-event-api/tips/TIP-0028/event-api.yml)
+[AsyncAPI Editor](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0028/event-api.yml)
 
 ## Rationale
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -1,5 +1,5 @@
 ---
-tip: 27
+tip: 28
 title: Event API
 description: Node event API definitions in AsyncAPI Specification
 author: Luca Moser (@luca-moser) <luca.moser@iota.org>, Levente Pap (@lzpap) <levente.pap@iota.org>
@@ -30,7 +30,7 @@ The event-based architecture should be of great benefit to:
 
 The API is described using the AsyncAPI Specification:
 
-[AsyncAPI Editor](https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/iotaledger/tips/stardust-event-api/tips/TIP-0028/event-api.yml)
+[AsyncAPI Editor](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/iotaledger/tips/stardust-event-api/tips/TIP-0028/event-api.yml)
 
 ## Rationale
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -47,8 +47,7 @@ The access route of the message broker should be updated to:
 
 ## Reference Implementation
 
- - https://github.com/gohornet/hornet/tree/develop/pkg/mqtt
- - https://github.com/gohornet/hornet/tree/develop/plugins/mqtt
+ - https://github.com/gohornet/hornet/tree/develop/tools/inx-mqtt
 
 ## Copyright
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -22,7 +22,7 @@ The event API makes it possible for clients to implement event-based architectur
 by the REST API defined in [draft TIP-25](../TIP-0025/tip-0025.md).
 
 The event-based architecture should be of great benefit to:
- - wallets monitoring status of submitted messages or transactions,
+ - wallets monitoring status of submitted blocks or transactions,
  - explorers displaying the evolution of the Tangle and ledger state,
  - archivers documenting the history of the Tangle.
 

--- a/tips/TIP-0028/tip-0028.md
+++ b/tips/TIP-0028/tip-0028.md
@@ -1,0 +1,55 @@
+---
+tip: 27
+title: Event API
+description: Node event API definitions in AsyncAPI Specification
+author: Luca Moser (@luca-moser) <luca.moser@iota.org>, Levente Pap (@lzpap) <levente.pap@iota.org>
+discussions-to: https://github.com/iotaledger/tips/pull/33
+status: Draft
+type: Standards
+layer: Interface
+created: 2022-03-02
+replaces: 16
+---
+
+## Abstract
+
+This proposal describes the [MQTT](https://mqtt.org/) based Node Event API for IOTA nodes. Clients may subscribe to
+topics provided by the node, that acts as the message publisher and broker at the same time.
+
+## Motivation
+
+The event API makes it possible for clients to implement event-based architectures as opposed to polling supported
+by the REST API defined in [draft TIP-25](../TIP-0025/tip-0025.md).
+
+The event-based architecture should be of great benefit to:
+ - wallets monitoring status of submitted messages or transactions,
+ - explorers displaying the evolution of the Tangle and ledger state,
+ - archivers documenting the history of the Tangle.
+
+## Specification
+
+The API is described using the AsyncAPI Specification:
+
+[AsyncAPI Editor](https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/iotaledger/tips/stardust-event-api/tips/TIP-0028/event-api.yml)
+
+## Rationale
+
+TBW
+
+## Backwards Compatibility
+
+The previously employed event API described in [TIP-16](../TIP-0016/tip-0016.md) is not backwards compatible with the
+current proposal, therefore versioning is introduced in the access URL of the API.
+
+Since the response models are shared between the REST API and the event API, this proposal implements API version `v2`.
+The access route of the message broker should be updated to:
+ - `{nodeURL}/plugins/mqtt/v2`
+
+## Reference Implementation
+
+ - https://github.com/gohornet/hornet/tree/develop/pkg/mqtt
+ - https://github.com/gohornet/hornet/tree/develop/plugins/mqtt
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Stardust update of the Node Event API originally defined in [TIP-16](https://github.com/iotaledger/tips/blob/main/tips/TIP-0016/tip-0016.md).
 - Updated object models
 - New subscription paths
 - Restructured address topics
 - Replaces [TIP-16](https://github.com/iotaledger/tips/blob/main/tips/TIP-0016/tip-0016.md)

[Rendered version](https://github.com/iotaledger/tips/blob/stardust-event-api/tips/TIP-0028/tip-0028.md)