### PR TITLE
TIP-31 Bech32 Address Format (updated)

### DIFF
--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -39,8 +39,8 @@ The address format uses a simple serialization scheme which consists of two part
 
 Currently, only three kind of addresses are supported:
  - Ed25519, where the address consists of the BLAKE2b-256 hash of the Ed25519 public key.
- - Alias, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> that created the alias.
- - NFT, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> that created the NFT.
+ - Alias, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the alias.
+ - NFT, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the NFT.
 
 They are serialized as follows:
 
@@ -55,7 +55,7 @@ They are serialized as follows:
 
 The human-readable encoding of the address is Bech32 (as described in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)). A Bech32 string is at most 90 characters long and consists of:
 
-- The **human-readable part** (HRP), which conveys the protocol and distinguishes between the different networks:
+- The **human-readable part** (HRP), which conveys the protocol and distinguishes between the different networks. HRPs are registered in [SLIP-0173]( https://github.com/satoshilabs/slips/blob/master/slip-0173.md):
    - `iota` is the human-readable part for IOTA Mainnet addresses (IOTA tokens)
    - `atoi` is the human-readable part for IOTA Testnet/Devnet addresses
   -  `smr` is the human-readable part for Shimmer network addresses (Shimmer tokens)
@@ -63,42 +63,34 @@ The human-readable encoding of the address is Bech32 (as described in [BIP-0173]
 - The **separator**, which is always `1`.
 - The **data part**, which consists of the Base32 encoded serialized address and the 6-character checksum.
 
-Hence,
- - Ed25519-based IOTA addresses will result in a Bech32 string of 64 characters.
- - Alias IOTA addresses will result in a Bech32 string of 44 characters.
- - NFT IOTA addresses will result in a Bech32 string of 44 characters.
- - Ed25519-based Shimmer addresses will result in a Bech32 string of 63 characters.
- - Alias Shimmer addresses will result in a Bech32 string of 43 characters.
- - NFT Shimmer addresses will result in a Bech32 string of 43 characters.
-
 ## Examples
 - Ed25519 Address
   - Ed25519 public key (32-byte): `6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8`
   - BLAKE2b-256 hash (32-byte): `efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
   - serialized (33-byte): `00efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
   - Bech32 string:
-    - **IOTA**:`iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx`
-    - **IOTA Testnet**: `atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t`
-    - **Shimmer**: `smr1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xhcazjh`
-    - **Shimmer Testnet**: `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
+    - **IOTA** (64-char):`iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx`
+    - **IOTA Testnet** (64-char): `atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t`
+    - **Shimmer** (63-char): `smr1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xhcazjh`
+    - **Shimmer Testnet**: (63-char) `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
 - Alias Address
   - _Output ID_ (34-byte): `52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
   - _Alias ID_, BLAKE2b-160 hash (20-byte): `6457f5f1bc2c3ec696889309cee0665c298f6394`
   - serialized (21-byte): `086457f5f1bc2c3ec696889309cee0665c298f6394
   - Bech32 string:
-    - **IOTA**: `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
-    - **IOTA Testnet**: `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
-    - **Shimmer**: `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
-    - **Shimmer Testnet**: `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
+    - **IOTA** (45-char): `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
+    - **IOTA Testnet** (45-char): `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
+    - **Shimmer** (44-char): `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
+    - **Shimmer Testnet** (44-char): `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
 - NFT Address
   - _Output ID_ (34-byte): `97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000`
   - _NFT ID_, BLAKE2b-160 hash (20-byte): `a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
   - serialized (21-byte): `10a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
   - Bech32 string:
-    - **IOTA**: `iota1zzsas86res7vrl5qck2ysxnrmemwkrfruyltffrq`
-    - **IOTA Testnet**: `atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg`
-    - **Shimmer**: `smr1zzsas86res7vrl5qck2ysxnrmemwkrfruygzqwn2`
-    - **Shimmer Testnet**: `rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9`
+    - **IOTA** (45-char): `iota1zzsas86res7vrl5qck2ysxnrmemwkrfruyltffrq`
+    - **IOTA Testnet** (45-char): `atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg`
+    - **Shimmer** (44-char): `smr1zzsas86res7vrl5qck2ysxnrmemwkrfruygzqwn2`
+    - **Shimmer Testnet** (44-char): `rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9`
 
 # Drawbacks
 
@@ -109,7 +101,6 @@ Hence,
 
 - There are several ways to convert the binary serialization into a human-readable format, e.g. Base58 or hexadecimal. The Bech32 format, however, offers the best compromise between compactness and error correction guarantees. A more detailed motivation can be found in [BIP-0173 Motivation](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#motivation).
 - The binary serialization itself must be as compact as possible while still allowing you to distinguish between different address types of the same byte length. As such, the introduction of a version byte offers support for up to 256 different kinds of addresses at only the cost of one single byte.
-- The HRP of the Bech32 string offers a good opportunity to clearly distinguish IOTA addresses from other Bech32 encoded data. Here, any three or four character ASCII strings can be used. However, selecting `iota` as well as `atoi` seems like the most recognizable option.
 
 # Reference implementation
 
@@ -120,6 +111,7 @@ Example Go implementation in [wollac/iota-crypto-demo](https://github.com/Wollac
 Example Go implementation in [iotaledger/iota.go/v3](https://github.com/iotaledger/iota.go/tree/v3):
  - Bech32 encoding: [bech32](https://github.com/iotaledger/iota.go/tree/v3/bech32)
  - Address implementations: [Ed25519](https://github.com/iotaledger/iota.go/blob/v3/address_ed25519.go), [Alias](https://github.com/iotaledger/iota.go/blob/v3/address_alias.go), [NFT](https://github.com/iotaledger/iota.go/blob/v3/address_nft.go)
+
 # Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -1,0 +1,122 @@
+---
+tip: 31
+title: Bech32 Address Format
+description: Extendable address format supporting various signature schemes and address types
+author: Wolfgang Welz (@Wollac) <wolfgang.welz@iota.org>, Levente Pap (@lzpap) <levente.pap@iota.org>
+discussions-to: https://github.com/iotaledger/tips/pull/20
+status: Draft
+type: Standards
+layer: Interface
+created: 2022-04-04
+replaces: 11
+---
+
+# Summary
+
+This document proposes an extendable address format for the IOTA protocol supporting various signature schemes and address types. It relies on the [Bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) format to provide a compact, human-readable encoding with strong error correction guarantees.
+
+# Motivation
+
+With [Chrysalis](https://roadmap.iota.org/chrysalis), IOTA started using Ed25519 to generate digital signatures, in which addresses correspond to a BLAKE2b-256 hash. It is necessary to define a universal and extendable address format capable of encoding different types of addresses (introduced also in [draft TIP-18](https://github.com/iotaledger/tips/pull/38)).
+
+The legacy IOTA protocol (1.0, pre-Chrysalis) relies on Base27 addresses with a truncated Kerl checksum. However, both the character set and the checksum algorithm have limitations:
+- Base27 is designed for ternary and is ill-suited for binary data.
+- The Kerl hash function also requires ternary input. Further, it is slow and provides no error-detection guarantees.
+- It does not support the addition of version or type information to distinguish between different kinds of addresses with the same length.
+
+All of these points are addressed in the Bech32 format introduced in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki): In addition to the usage of the human-friendly Base32 encoding with an optimized character set, it implements a [BCH code](https://en.wikipedia.org/wiki/BCH_code) that _guarantees detection_ of any error affecting at most four characters and has less than a 1 in 10<sup>9</sup> chance of failing to detect more errors.
+
+This TIP proposes a simple and extendable binary serialization for addresses of different types that is then Bech32 encoded to provide a unique appearance for human-facing applications such as wallets.
+
+# Detailed design
+
+## Binary serialization
+
+The address format uses a simple serialization scheme which consists of two parts:
+
+   - The first byte describes the type of the address.
+   - The remaining bytes contain the type-specific raw address bytes.
+
+Currently, only three kind of addresses are supported:
+ - Ed25519, where the address consists of the BLAKE2b-256 hash of the Ed25519 public key.
+ - Alias, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> that created the alias.
+ - NFT, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> that created the NFT.
+
+They are serialized as follows:
+
+| Type    | First byte | Address bytes                                                                  |
+|---------|------------|--------------------------------------------------------------------------------|
+| Ed25519 | `0x00`     | 32 bytes: The BLAKE2b-256 hash of the Ed25519 public key.                      |
+| Alias   | `0x08`     | 20 bytes: The BLAKE2b-160 hash of the <i>Output ID</i> that created the alias. |
+| NFT     | `0x10`     | 20 bytes: The BLAKE2b-160 hash of the <i>Output ID</i> that created the NFT.   |
+
+
+## Bech32 for human-readable encoding
+
+The human-readable encoding of the address is Bech32 (as described in [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)). A Bech32 string is at most 90 characters long and consists of:
+
+- The **human-readable part** (HRP), which conveys the protocol and distinguishes between the different networks:
+   - `iota` is the human-readable part for IOTA Mainnet addresses (IOTA tokens)
+   - `atoi` is the human-readable part for IOTA Testnet/Devnet addresses
+  -  `smr` is the human-readable part for Shimmer network addresses (Shimmer tokens)
+  -  `rms` is the human-readable part for Shimmer Testnet/Devnet addresses
+- The **separator**, which is always `1`.
+- The **data part**, which consists of the Base32 encoded serialized address and the 6-character checksum.
+
+Hence,
+ - Ed25519-based IOTA addresses will result in a Bech32 string of 64 characters.
+ - Alias IOTA addresses will result in a Bech32 string of 44 characters.
+ - NFT IOTA addresses will result in a Bech32 string of 44 characters.
+ - Ed25519-based Shimmer addresses will result in a Bech32 string of 63 characters.
+ - Alias Shimmer addresses will result in a Bech32 string of 43 characters.
+ - NFT Shimmer addresses will result in a Bech32 string of 43 characters.
+
+## Examples
+ - Ed25519 Address
+   - compressed public key (32-byte): `0x6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8`
+   - BLAKE2b-256 hash (32-byte): `0xefdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
+   - serialized (33-byte): `0x00efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
+   - **IOTA Mainnet** Bech32 string: `iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx`
+   - **IOTA Testnet** Bech32 string: `atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t`
+   - **Shimmer** Bech32 string: `smr1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xhcazjh`
+   - **Shimmer Testnet** Bech32 string: `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
+ - Alias Address
+   - <i>Output ID</i> that created it (34 bytes): `0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
+   - <i>Alias ID</i>, BLAKE2b-160 hash (20 bytes): `0x6457f5f1bc2c3ec696889309cee0665c298f6394`
+   - serialized (21 bytes): `0x086457f5f1bc2c3ec696889309cee0665c298f6394`
+   - **IOTA Mainnet** Bech32 string: `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
+   - **IOTA Testnet** Bech32 string: `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
+   - **Shimmer** Bech32 string: `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
+   - **Shimmer Testnet** Bech32 string: `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
+ - NFT Address
+   - <i>Output ID</i> that created it (34 bytes): `0x97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000`
+   - <i>NFT ID</i>, BLAKE2b-160 hash (20 bytes): `0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd`
+   - serialized (21 bytes): `0x1089168d92d0b88cdb4f80c0eb830bb4bed3441fcd`
+   - **IOTA Mainnet** Bech32 string: `iota1zzy3drvj6zugek60srqwhqctkjldx3qle5yuvapj`
+   - **IOTA Testnet** Bech32 string: `atoi1zzy3drvj6zugek60srqwhqctkjldx3qle5fhvhm6`
+   - **Shimmer** Bech32 string: `smr1zzy3drvj6zugek60srqwhqctkjldx3qle5n4963c`
+   - **Shimmer Testnet** Bech32 string: `rms1zzy3drvj6zugek60srqwhqctkjldx3qle55ke5wh`
+
+# Drawbacks
+
+- Addresses look fundamentally different from the established 81-tryte legacy IOTA addresses. However, since the switch from binary to ternary and Chrysalis in general was a substantial change, this is a very reasonable and desired consequence.
+- A four character HRP plus one type byte only leaves a maximum of 48 bytes for the actual address.
+
+# Rationale and alternatives
+
+- There are several ways to convert the binary serialization into a human-readable format, e.g. Base58 or hexadecimal. The Bech32 format, however, offers the best compromise between compactness and error correction guarantees. A more detailed motivation can be found in [BIP-0173 Motivation](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#motivation).
+- The binary serialization itself must be as compact as possible while still allowing you to distinguish between different address types of the same byte length. As such, the introduction of a version byte offers support for up to 256 different kinds of addresses at only the cost of one single byte.
+- The HRP of the Bech32 string offers a good opportunity to clearly distinguish IOTA addresses from other Bech32 encoded data. Here, any three or four character ASCII strings can be used. However, selecting `iota` as well as `atoi` seems like the most recognizable option.
+
+# Reference implementation
+
+Example Go implementation in [wollac/iota-crypto-demo](https://github.com/Wollac/iota-crypto-demo):
+- Bech32 encoding: [pkg/bech32](https://github.com/Wollac/iota-crypto-demo/tree/master/pkg/bech32)
+- Example: [examples/bech32](https://github.com/Wollac/iota-crypto-demo/tree/master/examples/bech32)
+
+Example Go implementation in [iotaledger/iota.go/v3](https://github.com/iotaledger/iota.go/tree/v3):
+ - Bech32 encoding: [bech32](https://github.com/iotaledger/iota.go/tree/v3/bech32)
+ - Address implementations: [Ed25519](https://github.com/iotaledger/iota.go/blob/v3/address_ed25519.go), [Alias](https://github.com/iotaledger/iota.go/blob/v3/address_alias.go), [NFT](https://github.com/iotaledger/iota.go/blob/v3/address_nft.go)
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -39,16 +39,16 @@ The address format uses a simple serialization scheme which consists of two part
 
 Currently, only three kind of addresses are supported:
  - Ed25519, where the address consists of the BLAKE2b-256 hash of the Ed25519 public key.
- - Alias, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the alias.
- - NFT, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the NFT.
+ - Alias, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the alias.
+ - NFT, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> (defined in [draft TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md#utxo-input)) that created the NFT.
 
 They are serialized as follows:
 
 | Type    | First byte | Address bytes                                                                  |
 |---------|------------|--------------------------------------------------------------------------------|
 | Ed25519 | `0x00`     | 32 bytes: The BLAKE2b-256 hash of the Ed25519 public key.                      |
-| Alias   | `0x08`     | 20 bytes: The BLAKE2b-160 hash of the <i>Output ID</i> that created the alias. |
-| NFT     | `0x10`     | 20 bytes: The BLAKE2b-160 hash of the <i>Output ID</i> that created the NFT.   |
+| Alias   | `0x08`     | 32 bytes: The BLAKE2b-256 hash of the <i>Output ID</i> that created the alias. |
+| NFT     | `0x10`     | 32 bytes: The BLAKE2b-256 hash of the <i>Output ID</i> that created the NFT.   |
 
 
 ## Bech32 for human-readable encoding
@@ -75,22 +75,22 @@ The human-readable encoding of the address is Bech32 (as described in [BIP-0173]
     - **Shimmer Testnet**: (63-char) `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
 - Alias Address
   - _Output ID_ (34-byte): `52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
-  - _Alias ID_, BLAKE2b-160 hash (20-byte): `6457f5f1bc2c3ec696889309cee0665c298f6394`
-  - serialized (21-byte): `086457f5f1bc2c3ec696889309cee0665c298f6394`
+  - _Alias ID_, BLAKE2b-256 hash (32-byte): `fe80c2eb7c736da2f7c98ecf135ee9e34e4e076afe6e1dfebc9ec578b8f56d2f`
+  - serialized (33-byte): `08fe80c2eb7c736da2f7c98ecf135ee9e34e4e076afe6e1dfebc9ec578b8f56d2f`
   - Bech32 string:
-    - **IOTA** (45-char): `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
-    - **IOTA Testnet** (45-char): `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
-    - **Shimmer** (44-char): `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
-    - **Shimmer Testnet** (44-char): `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
+    - **IOTA** (64-char): `iota1prlgpsht03ekmghhex8v7y67a835uns8dtlxu807hj0v279c74kj76j6rev`
+    - **IOTA Testnet** (64-char): `atoi1prlgpsht03ekmghhex8v7y67a835uns8dtlxu807hj0v279c74kj7autzrp`
+    - **Shimmer** (63-char): `smr1prlgpsht03ekmghhex8v7y67a835uns8dtlxu807hj0v279c74kj7dzrr0a`
+    - **Shimmer Testnet** (63-char): `rms1prlgpsht03ekmghhex8v7y67a835uns8dtlxu807hj0v279c74kj7e9ge5y`
 - NFT Address
   - _Output ID_ (34-byte): `97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000`
-  - _NFT ID_, BLAKE2b-160 hash (20-byte): `a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
-  - serialized (21-byte): `10a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
+  - _NFT ID_, BLAKE2b-256 hash (32-byte): `3159b115e27128b6db16db5e61f1aa4c70d84a99be753faa3ee70d9ad9c6a6b7`
+  - serialized (33-byte): `103159b115e27128b6db16db5e61f1aa4c70d84a99be753faa3ee70d9ad9c6a6b7`
   - Bech32 string:
-    - **IOTA** (45-char): `iota1zzsas86res7vrl5qck2ysxnrmemwkrfruyltffrq`
-    - **IOTA Testnet** (45-char): `atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg`
-    - **Shimmer** (44-char): `smr1zzsas86res7vrl5qck2ysxnrmemwkrfruygzqwn2`
-    - **Shimmer Testnet** (44-char): `rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9`
+    - **IOTA** (64-char): `iota1zqc4nvg4ufcj3dkmzmd4uc034fx8pkz2nxl820a28mnsmxkec6ntw0vklm7`
+    - **IOTA Testnet** (64-char): `atoi1zqc4nvg4ufcj3dkmzmd4uc034fx8pkz2nxl820a28mnsmxkec6ntwgz87pn`
+    - **Shimmer** (63-char): `smr1zqc4nvg4ufcj3dkmzmd4uc034fx8pkz2nxl820a28mnsmxkec6ntwcu0ld0`
+    - **Shimmer Testnet** (63-char): `rms1zqc4nvg4ufcj3dkmzmd4uc034fx8pkz2nxl820a28mnsmxkec6ntwvmy9kk`
 
 # Drawbacks
 

--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -76,7 +76,7 @@ The human-readable encoding of the address is Bech32 (as described in [BIP-0173]
 - Alias Address
   - _Output ID_ (34-byte): `52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
   - _Alias ID_, BLAKE2b-160 hash (20-byte): `6457f5f1bc2c3ec696889309cee0665c298f6394`
-  - serialized (21-byte): `086457f5f1bc2c3ec696889309cee0665c298f6394
+  - serialized (21-byte): `086457f5f1bc2c3ec696889309cee0665c298f6394`
   - Bech32 string:
     - **IOTA** (45-char): `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
     - **IOTA Testnet** (45-char): `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`

--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -39,8 +39,8 @@ The address format uses a simple serialization scheme which consists of two part
 
 Currently, only three kind of addresses are supported:
  - Ed25519, where the address consists of the BLAKE2b-256 hash of the Ed25519 public key.
- - Alias, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> that created the alias.
- - NFT, where the address consists of the BLAKE2b-256 hash of the <i>Output ID</i> that created the NFT.
+ - Alias, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> that created the alias.
+ - NFT, where the address consists of the BLAKE2b-160 hash of the <i>Output ID</i> that created the NFT.
 
 They are serialized as follows:
 

--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -72,30 +72,33 @@ Hence,
  - NFT Shimmer addresses will result in a Bech32 string of 43 characters.
 
 ## Examples
- - Ed25519 Address
-   - compressed public key (32-byte): `0x6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8`
-   - BLAKE2b-256 hash (32-byte): `0xefdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
-   - serialized (33-byte): `0x00efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
-   - **IOTA Mainnet** Bech32 string: `iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx`
-   - **IOTA Testnet** Bech32 string: `atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t`
-   - **Shimmer** Bech32 string: `smr1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xhcazjh`
-   - **Shimmer Testnet** Bech32 string: `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
- - Alias Address
-   - <i>Output ID</i> that created it (34 bytes): `0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
-   - <i>Alias ID</i>, BLAKE2b-160 hash (20 bytes): `0x6457f5f1bc2c3ec696889309cee0665c298f6394`
-   - serialized (21 bytes): `0x086457f5f1bc2c3ec696889309cee0665c298f6394`
-   - **IOTA Mainnet** Bech32 string: `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
-   - **IOTA Testnet** Bech32 string: `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
-   - **Shimmer** Bech32 string: `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
-   - **Shimmer Testnet** Bech32 string: `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
- - NFT Address
-   - <i>Output ID</i> that created it (34 bytes): `0x97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000`
-   - <i>NFT ID</i>, BLAKE2b-160 hash (20 bytes): `0x89168d92d0b88cdb4f80c0eb830bb4bed3441fcd`
-   - serialized (21 bytes): `0x1089168d92d0b88cdb4f80c0eb830bb4bed3441fcd`
-   - **IOTA Mainnet** Bech32 string: `iota1zzy3drvj6zugek60srqwhqctkjldx3qle5yuvapj`
-   - **IOTA Testnet** Bech32 string: `atoi1zzy3drvj6zugek60srqwhqctkjldx3qle5fhvhm6`
-   - **Shimmer** Bech32 string: `smr1zzy3drvj6zugek60srqwhqctkjldx3qle5n4963c`
-   - **Shimmer Testnet** Bech32 string: `rms1zzy3drvj6zugek60srqwhqctkjldx3qle55ke5wh`
+- Ed25519 Address
+  - Ed25519 public key (32-byte): `6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8`
+  - BLAKE2b-256 hash (32-byte): `efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
+  - serialized (33-byte): `00efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3`
+  - Bech32 string:
+    - **IOTA**:`iota1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xqgyzyx`
+    - **IOTA Testnet**: `atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t`
+    - **Shimmer**: `smr1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xhcazjh`
+    - **Shimmer Testnet**: `rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw`
+- Alias Address
+  - _Output ID_ (34-byte): `52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000`
+  - _Alias ID_, BLAKE2b-160 hash (20-byte): `6457f5f1bc2c3ec696889309cee0665c298f6394`
+  - serialized (21-byte): `086457f5f1bc2c3ec696889309cee0665c298f6394
+  - Bech32 string:
+    - **IOTA**: `iota1ppj90a03hskra35k3zfsnnhqvewznrmrjsxjvqlj`
+    - **IOTA Testnet**: `atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296`
+    - **Shimmer**: `smr1ppj90a03hskra35k3zfsnnhqvewznrmrjs3m980c`
+    - **Shimmer Testnet**: `rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh`
+- NFT Address
+  - _Output ID_ (34-byte): `97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000`
+  - _NFT ID_, BLAKE2b-160 hash (20-byte): `a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
+  - serialized (21-byte): `10a1d81f43cc3cc1fe80c594481a63de76eb0d23e1`
+  - Bech32 string:
+    - **IOTA**: `iota1zzsas86res7vrl5qck2ysxnrmemwkrfruyltffrq`
+    - **IOTA Testnet**: `atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg`
+    - **Shimmer**: `smr1zzsas86res7vrl5qck2ysxnrmemwkrfruygzqwn2`
+    - **Shimmer Testnet**: `rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9`
 
 # Drawbacks
 


### PR DESCRIPTION
 - Replaces [TIP-11](https://github.com/iotaledger/tips/blob/main/tips/TIP-0011/tip-0011.md)
 - Extends bech32 support for Alias and NFT addresses
 - Adds Shimmer HRPs `smr` and `rms`

[Rendered Version](https://github.com/iotaledger/tips/blob/add-smr-hrps/tips/TIP-0031/tip-0031.md)