### PR TITLE
Updated TIP35 to support delta snapshot updates

### DIFF
--- a/tips/TIP-0035/tip-0035.md
+++ b/tips/TIP-0035/tip-0035.md
@@ -13,7 +13,7 @@ replaces: 9
 
 # Summary
 
-This RFC defines a file format for local snapshots which is compatible with Stardust.
+This TIP defines a file format for local snapshots which is compatible with Stardust.
 
 # Motivation
 
@@ -27,7 +27,7 @@ at the point of the snapshot index in order extract startup metadata from it.
 
 # Detailed design
 
-Since a UTXO based ledger is much larger in size, this RFC proposes two formats for snapshot files:
+Since a UTXO based ledger is much larger in size, this TIP proposes two formats for snapshot files:
 
 * A `full` format which represents a complete ledger state.
 * A `delta` format which only contains diffs (created and consumed outputs) of milestones from a given milestone index
@@ -35,9 +35,6 @@ Since a UTXO based ledger is much larger in size, this RFC proposes two formats 
 
 This separation allows nodes to swiftly create new delta snapshot files, which then can be distributed with a companion
 full snapshot file to reconstruct a recent state.
-
-Unlike the current format, these new formats do not include spent addresses since this information is no longer held by
-nodes.
 
 ### Formats
 
@@ -47,7 +44,7 @@ nodes.
 
 A full ledger snapshot file contains the UTXOs (`outputs` section) of a node's confirmed
 milestone (`Ledger Milestone Index`). The `diffs` contain the diffs to rollback the `outputs` state to regain the ledger
-state of the snapshot SEP milestone.
+state of the snapshot `Target Milestone Index`.
 
 ![](diffs_1.png)
 
@@ -57,8 +54,7 @@ state, this is deferred to the consumer of the data to speed up local snapshot c
 #### Delta Ledger State
 
 A delta ledger state local snapshot only contains the `diffs` of milestones starting from a
-given `Ledger Milestone Index`. A node consuming such data must know the state of the ledger at `Ledger Milestone Index`
-.
+given `Full Snapshot Target Milestone Index`. A node consuming such data must know the state of the ledger at `Full Snapshot Target Milestone Index`.
 
 ![](diffs_2.png)
 
@@ -80,9 +76,9 @@ Defines an output.
         <td>The ID of the output which is a concatenation of the transaction ID + output index.</td>
     </tr>
     <tr>
-        <td>Message Hash</td>
+        <td>Block ID</td>
         <td>Array<byte>[32]</td>
-        <td>The hash of the message in which the transaction was contained which generated this output.</td>
+        <td>The ID of the Block in which the transaction was contained which generated this output.</td>
     </tr>
     <tr>
         <td>Milestone Index</td>
@@ -92,7 +88,7 @@ Defines an output.
     <tr>
         <td>Milestone Timestamp</td>
         <td>uint32</td>
-        <td>The timestamp of the milestone which produced this output.</td>
+        <td>The UNIX timestamp in seconds of the milestone which produced this output.</td>
     </tr>
     <tr>
         <td valign="top">Output <code>oneOf</code></td>
@@ -113,6 +109,28 @@ Defines an output.
     </tr>
 </table>
 
+##### Consumed Output
+
+Defines a consumed output.
+
+<table>
+    <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td>Output</td>
+        <td>Array<byte>[Output length]</td>
+        <td>The serialized Output (see above).</td>
+    </tr>
+    <tr>
+        <td>Target Transaction ID</td>
+        <td>Array<byte>[32]</td>
+        <td>The ID of the transaction that spent this output.</td>
+    </tr>
+</table>
+
 ##### Milestone Diff
 
 Defines the diff a milestone produced by listing the created/consumed outputs and the milestone payload itself.
@@ -124,7 +142,7 @@ Defines the diff a milestone produced by listing the created/consumed outputs an
         <th>Description</th>
     </tr>
     <tr>
-        <td>Milestone Payload length</td>
+        <td>Milestone Payload Length</td>
         <td>uint32</td>
         <td>Denotes the length of the milestone payload.</td>
     </tr>
@@ -162,7 +180,7 @@ Defines the diff a milestone produced by listing the created/consumed outputs an
     </tr>
     <tr>
         <td>Created Outputs Count</td>
-        <td>uint64</td>
+        <td>uint32</td>
         <td>The amount of outputs generated with this milestone diff.</td>
     </tr>
     <tr>
@@ -175,14 +193,14 @@ Defines the diff a milestone produced by listing the created/consumed outputs an
     </tr>
     <tr>
         <td>Consumed Outputs Count</td>
-        <td>uint64</td>
+        <td>uint32</td>
         <td>The amount of outputs consumed with this milestone diff.</td>
     </tr>
     <tr>
         <td valign="top">Consumed Outputs <code>anyOf</code></td>
         <td colspan="2">
             <details>
-                <summary>Output</summary>
+                <summary>Consumed Output</summary>
             </details>
         </td>
     </tr>
@@ -205,22 +223,22 @@ Defines protocol parameters.
     </tr>
     <tr>
         <td>Network Name</td>
-        <td>string</td>
+        <td>(uint8)string</td>
         <td>Then name of the network from which this snapshot was generated from.</td>
     </tr>
     <tr>
         <td>Bech32HRP</td>
-        <td>string</td>
+        <td>(uint8)string</td>
         <td>The human-readable part of the addresses within the network.</td>
     </tr>
     <tr>
         <td>MinPoWScore</td>
-        <td>float64</td>
+        <td>uint32</td>
         <td>The minimum PoW score.</td>
     </tr>
     <tr>
         <td>BelowMaxDepth</td>
-        <td>uint16</td>
+        <td>uint8</td>
         <td>The below max depth parameter.</td>
     </tr>
     <tr>
@@ -234,17 +252,17 @@ Defines protocol parameters.
                 </tr>
                 <tr>
                     <td>VByteCost</td>
-                    <th>uint64</th>
+                    <th>uint32</th>
                     <td>The token price per virtual byte</td>
                 </tr>
                 <tr>
                     <td>VBFactorData</td>
-                    <th>uint64</th>
+                    <th>uint8</th>
                     <td>The factor to use for data fields</td>
                 </tr>
                 <tr>
                     <td>VBFactorKey</td>
-                    <th>uint64</th>
+                    <th>uint8</th>
                     <td>The factor to use for indexed fields</td>
                 </tr>
             </table>
@@ -278,57 +296,34 @@ Defines what a full snapshot file contains.
         <td>Denotes the type of this file format. <b>Value 0</b> denotes a full snapshot.</td>
     </tr>
     <tr>
-        <td>Timestamp</td>
-        <td>uint32</td>
-        <td>The UNIX timestamp in seconds of when this snapshot was produced.</td>
-    </tr>
-    <tr>
         <td>First Milestone Index</td>
         <td>uint32</td>
-        <td>The index of the first milestone. Zero if there is none.</td>
+        <td>The index of the first milestone of the network. Zero if there is none.</td>
     </tr>
     <tr>
-        <td valign="top">Protocol Parameter</td>
-        <td colspan="2">
-            <details>
-                <summary>Protocol Parameter</summary>
-            </details>
-        </td>
-    </tr>
-    <tr>
-        <td>SEP Milestone Payload length</td>
+        <td>Ledger Milestone Index</td>
         <td>uint32</td>
-        <td>Denotes the length of the SEP milestone payload.</td>
+        <td>The index of the milestone of which the UTXOs within the snapshot are from.</td>
     </tr>
     <tr>
-        <td>SEP Milestone Payload</td>
-        <td>Array<byte>[Milestone Payload length]</td>
-        <td>The milestone payload in its serialized binary form.</td>
-    </tr>
-    <tr>
-        <td>Ledger milestone index</td>
+        <td>Target Milestone Index</td>
         <td>uint32</td>
-        <td>The milestone index of which the UTXOs within the snapshot are from.</td>
+        <td>The index of the milestone of which the SEPs within the snapshot are from.</td>
     </tr>
     <tr>
-        <td>SEPs count</td>
-        <td>uint64</td>
-        <td>The amount of SEPs contained within this snapshot.</td>
+        <td>Target Milestone Timestamp</td>
+        <td>uint32</td>
+        <td>The UNIX timestamp in seconds of the milestone of which the SEPs within the snapshot are from.</td>
     </tr>
     <tr>
-        <td>Outputs count</td>
-        <td>uint64</td>
-        <td>The amount of UTXOs contained within this snapshot.</td>
-    </tr>
-    <tr>
-        <td>Milestone diffs count</td>
-        <td>uint64</td>
-        <td>The amount of milestone diffs contained within this snapshot.</td>
-    </tr>
-    <tr>
-        <td>Treasury Output Milestone Hash</td>
+        <td>Target Milestone ID</td>
         <td>Array<byte>[32]</td>
-        <td>The milestone hash of the milestone which generated the treasury output.</td>
+        <td>The ID of the milestone of which the SEPs within the snapshot are from.</td>
+    </tr>
+    <tr>
+        <td>Treasury Output Milestone ID</td>
+        <td>Array<byte>[32]</td>
+        <td>The milestone ID of the milestone which generated the treasury output.</td>
     </tr>
     <tr>
         <td>Treasury Output Amount</td>
@@ -336,12 +331,32 @@ Defines what a full snapshot file contains.
         <td>The amount of funds residing on the treasury output.</td>
     </tr>
     <tr>
-        <td valign="top">SEPs</td>
+        <td>Protocol Parameter Length</td>
+        <td>uint16</td>
+        <td>Denotes the length of the Protocol Parameter.</td>
+    </tr>
+    <tr>
+        <td valign="top">Protocol Parameter</td>
         <td colspan="2">
             <details>
-                <summary>SEP Array<byte>[32]</summary>
+                <summary>Protocol Parameter that are active at the milestone of which the UTXOs within the snapshot are from.</summary>
             </details>
         </td>
+    </tr>
+    <tr>
+        <td>Outputs Count</td>
+        <td>uint64</td>
+        <td>The amount of UTXOs contained within this snapshot.</td>
+    </tr>
+    <tr>
+        <td>Milestone Diffs Count</td>
+        <td>uint32</td>
+        <td>The amount of milestone diffs contained within this snapshot.</td>
+    </tr>
+    <tr>
+        <td>SEPs Count</td>
+        <td>uint16</td>
+        <td>The amount of SEPs contained within this snapshot.</td>
     </tr>
     <tr>
         <td valign="top">Outputs</td>
@@ -356,6 +371,14 @@ Defines what a full snapshot file contains.
         <td colspan="2">
             <details>
                 <summary>Milestone Diff</summary>
+            </details>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top">SEPs</td>
+        <td colspan="2">
+            <details>
+                <summary>SEP Array<byte>[32]</summary>
             </details>
         </td>
     </tr>
@@ -382,50 +405,34 @@ Defines what a delta snapshot contains.
         <td>Denotes the type of this file format. <b>Value 1</b> denotes a delta snapshot.</td>
     </tr>
     <tr>
-        <td>Timestamp</td>
-        <td>uint64</td>
-        <td>The UNIX timestamp in seconds of when this snapshot was produced.</td>
-    </tr>
-    <tr>
-        <td valign="top">Protocol Parameter</td>
-        <td colspan="2">
-            <details>
-                <summary>Protocol Parameter</summary>
-            </details>
-        </td>
-    </tr>
-    <tr>
-        <td>SEP Milestone Payload length</td>
+        <td>Target Milestone Index</td>
         <td>uint32</td>
-        <td>Denotes the length of the SEP milestone payload.</td>
+        <td>The index of the milestone of which the SEPs within the snapshot are from.</td>
     </tr>
     <tr>
-        <td>SEP Milestone Payload</td>
-        <td>Array<byte>[Milestone Payload length]</td>
-        <td>The milestone payload in its serialized binary form.</td>
+        <td>Target Milestone Timestamp</td>
+        <td>uint32</td>
+        <td>The UNIX timestamp in seconds of the milestone of which the SEPs within the snapshot are from.</td>
     </tr>
     <tr>
-        <td>Ledger milestone index</td>
+        <td>Full Snapshot Target Milestone ID</td>
+        <td>Array<byte>[32]</td>
+        <td>The ID of the target milestone of the full snapshot this delta snapshot builts up from.</td>
+    </tr>
+    <tr>
+        <td>SEP File Offset</td>
         <td>uint64</td>
-        <td>The milestone index up on which this delta snapshot builts up from.</td>
+        <td>The file offset of the SEPs field. This is used to easily update an existing delta snapshot without parsing its content.</td>
     </tr>
     <tr>
-        <td>SEPs count</td>
-        <td>uint64</td>
-        <td>The amount of SEPs contained within this snapshot.</td>
-    </tr>
-    <tr>
-        <td>Milestone diffs count</td>
-        <td>uint64</td>
+        <td>Milestone Diffs Count</td>
+        <td>uint32</td>
         <td>The amount of milestone diffs contained within this snapshot.</td>
     </tr>
     <tr>
-        <td valign="top">SEPs</td>
-        <td colspan="2">
-            <details>
-                <summary>SEP Array<byte>[32]</summary>
-            </details>
-        </td>
+        <td>SEPs Count</td>
+        <td>uint16</td>
+        <td>The amount of SEPs contained within this snapshot.</td>
     </tr>
     <tr>
         <td valign="top">Milestone Diffs</td>
@@ -435,7 +442,33 @@ Defines what a delta snapshot contains.
             </details>
         </td>
     </tr>
+    <tr>
+        <td valign="top">SEPs</td>
+        <td colspan="2">
+            <details>
+                <summary>SEP Array<byte>[32]</summary>
+            </details>
+        </td>
+    </tr>
 </table>
+
+# Updating an existing Delta snapshot file
+
+When creating a delta snapshot, an existing delta snapshot file can be reused.
+
+In order to do that, the following steps need to be done:
+1. Open the existing delta snapshot file.
+2. Read the existing delta snapshot file header.
+3. Verify that `Version` and `Full Snapshot Target Milestone ID` match between the existing and new delta snapshot.
+4. Seek to the position of `Target Milestone Index` and replace it with the new value.
+5. Seek to the position of `Target Milestone Timestamp` and replace it with the new value.
+6. Seek to the position of `SEP File Offset` and truncate the file at this position.
+7. Add the additional `Milestone Diffs` at this position.
+8.  Add the new `SEPs`.
+9.  Seek to the position of `SEP File Offset` and replace it with the new value.
+10. Seek to the position of `Milestone Diffs Count` and replace it with the new value.
+11. Seek to the position of `SEPs Count` and replace it with the new value.
+12. Close the file.
 
 # Drawbacks
 


### PR DESCRIPTION
This PR proposes a new full and delta snapshot layout to support reusing existing delta snapshot files.

`SEP Milestone Index` was renamed to `Target Milestone Index` for easier understanding.

It also adds the ability to identify the matching companion full snapshot inside a delta snapshot by providing the index and ID of the full snapshot target milestone.

The data types of several fields were modified to save space.
The full snapshot file format was also extended by the actual target index.
This way it is possible to add more milestone diffs than the SEP target, to recognize future protocol updates that are in the range between `below max depth` and the `target milestone index`.