### PR TITLE
Enforce lowercase on node features

### DIFF
--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -1218,7 +1218,7 @@ components:
           decimals: 0
           useMetricPrefix: true
         features:
-          - PoW
+          - pow
     get-info-response-example-shimmer:
       value:
         name: HORNET
@@ -1272,7 +1272,7 @@ components:
           subunit: "glow"
           useMetricPrefix: false
         features:
-          - PoW
+          - pow
 
     get-tips-response-example:
       value:
@@ -2994,7 +2994,7 @@ components:
             - decimals
             - useMetricPrefix
         features:
-          description: The features that are supported by the node. For example, a node could support the Proof-of-Work (PoW) feature, which would allow the PoW to be performed by the node itself.
+          description: The features that are supported by the node. For example, a node could support the Proof-of-Work (pow) feature, which would allow the Proof-of-Work to be performed by the node itself. All features must be lowercase.
           type: array
           items:
             type: string


### PR DESCRIPTION
There were several discussions about the casing of `PoW` in the info endpoint.

It is safer to enforce lowercase for every feature on the node side for easier string comparison on the client side.

Hint: The client side could also convert all features it receives via the info endpoint to lowercase before comparing with the needed feature, to make the check more fail safe against non-conform node implementations.
