### PR TITLE
Change genesis addresses for shimmer network

### DIFF
--- a/tips/TIP-0032/tip-0032.md
+++ b/tips/TIP-0032/tip-0032.md
@@ -72,7 +72,7 @@ The IOTA community carried out an [on-chain vote](https://github.com/iotaledger/
 The [community-validated result](https://github.com/iotaledger/participation-events/pull/10/files) of the vote allocated 10% of the new total Shimmer supply to a Shimmer Community Treasury DAO.
 
 As a consequence, the **genesis Shimmer snapshot allocates 181,362,050,906,137 `glow` (~181,362,051 `SMR`) to the address of the Shimmer Community Treasury**:
- - **smr1qrw3jem4c97vyp050za8qh4vss8cdxc30a39djmv8sd3tj99tea2s5ucg00**
+ - **smr1qrmakyqt5ezm5k9c0sk39gwfavpktxkjmx0jvh9ejxjq6pr6d39egv2mvuc**
 
 ### Tangle Ecosystem Association (TEA) - 10%
 
@@ -81,7 +81,7 @@ The Tangle Ecosystem Association was set up by the IOTA Foundation to host the n
 The [community-validated result](https://github.com/iotaledger/participation-events/pull/10/files) of the same [on-chain vote](https://github.com/iotaledger/participation-events/blob/master/events/vote/shimmer_funding.json) on the initial [Shimmer Ecosystem Funding Proposal](https://govern.iota.org/t/discussion-proposal-to-increase-the-shimmer-supply-for-a-community-treasury/1291) and its [follow-up proposal](https://govern.iota.org/t/discussion-follow-up-proposal-to-the-establishment-of-a-shimmer-ecosystem-fund/1315) allocates 10% of the total Shimmer genesis supply to the Tangle Ecosystem Association.
 
 As a consequence, the **genesis Shimmer snapshot allocates 181,362,050,906,136 `glow` (~181,362,051 `SMR`) to the address of the Tangle Ecosystem Association**:
- - **smr1qrtynzsrjhkq93cmg6zz093hrrsalp2tefggrn0nv9k84rcfnn2m529vdxw**
+ - **smr1qpjva0y6qwjmv42dspw2se2776l5qr0r5p2s5m7nrg73qhvm6a6y7uvqxn6**
 
 ## Global Parameters
 


### PR DESCRIPTION
This PR changes the genesis addresses for `Shimmer Community Treasury (DAO)` and `Tangle Ecosystem Association (TEA)`.