### PR TITLE
Fix: Add syntactic validation rule for max data length

### DIFF
--- a/tips/TIP-0023/tip-0023.md
+++ b/tips/TIP-0023/tip-0023.md
@@ -34,7 +34,8 @@ It is important to note that `Tag` is not considered by the protocol, it just se
 
 ## Syntactic Validation
 
-- `length(Tag)` must not be larger than [`Max Tag Length`](../TIP-0022/tip-0022.md).
+- `length(Tag)` must not be larger than `Max Tag Length` for [`Iota`](../TIP-0022/tip-0022.md) and [`Shimmer`](../TIP-0032/tip-0032.md), respectively.
+- `length(Data)` must not be larger than `Max Medatada Length` for [`Iota`](../TIP-0022/tip-0022.md) and [`Shimmer`](../TIP-0032/tip-0032.md), respectively.
 - Given the type and length information, the _Tagged Data Payload_ must consume the entire byte array of the `Payload` field of the encapsulating object.
 
 # Rationale


### PR DESCRIPTION
- Added Tagged Data Payload syntactic validation rule for max length of the data field.
- Updated Syntactic rules to reference protocol parameters for Iota and Shimmer.