### PR TITLE
fix typo on the formula of min_deposit_of_output

### DIFF
--- a/tips/TIP-0019/tip-0019.md
+++ b/tips/TIP-0019/tip-0019.md
@@ -48,7 +48,7 @@ Blocks including payloads, even transaction payloads, are considered to be prune
 
 **Every output created by a transaction needs to have at least a minimum amount of IOTA coins deposited in the output itself, otherwise the output is syntactically invalid.**
 
-min_deposit_of_output = ⌊v_byte_cost · v_byte⌋
+min_deposit_of_output = ⌊v_byte_cost · v_byte⌋  
 v_byte = ∑(weight<sub>𝑖</sub> · byte_size<sub>𝑖</sub>) + offset
 
 where:


### PR DESCRIPTION
Putting the 2 formulas on the same line could be confusing. The later could lead to think that min_deposit_of_output = ∑(weight𝑖 · byte_size𝑖) + offset .