### PR TITLE
Wiki - Update testnet networkName and networkId in TIP-020

### DIFF
--- a/tips/TIP-0020/tip-0020.md
+++ b/tips/TIP-0020/tip-0020.md
@@ -247,13 +247,13 @@ The <i>Transaction Essence</i> of a <i>Transaction Payload</i> carries the input
 #### Network ID
 
 The `Network ID` field of the transaction essence serves as a [replay protection mechanism](https://github.com/iotaledger/tips/discussions/56).
-It is a unique value denoting whether the transaction was meant for the IOTA mainnet, shimmer, testnet, or a private network. It consists of the first 8 bytes of the BLAKE2b-256 hash of the `Network Name` protocol parameter, interpreted as an unsigned integer number.
+It is a unique value denoting whether the transaction was meant for the IOTA mainnet, shimmer, testnet-1, or a private network. It consists of the first 8 bytes of the BLAKE2b-256 hash of the `Network Name` protocol parameter, interpreted as an unsigned integer number.
 
 | Network Name        | Resulting `Network ID` | Network Name defined in                             |
 |---------------------|------------------------|-----------------------------------------------------|
 | `iota-mainnet`      | `9374574019616453254`  | [TIP-22](../TIP-0022/tip-0022.md#detailed-design)   |
 | `shimmer`           | `14364762045254553490` | [TIP-32](../TIP-0032/tip-0032.md#global-parameters) |
-| `testnet`           | `8342982141227064571`  | -                                                   |
+| `testnet-1`         | `1856588631910923207`  | -                                                   |
 | `example-mynetwork` | `1967754805504104511`  | -                                                   |
 
 #### Inputs


### PR DESCRIPTION
# Description of change

Updated testnet `networkName` to `testnet-1` and `networkId` to  `1856588631910923207` in TIP-020

## Type of change

- Documentation Fix

## Related Issues

partially addresses https://github.com/iotaledger/guild-devx/issues/8

## How the change has been tested

Wiki was built locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
