### PR TITLE
Fix formatting in tip18

### DIFF
--- a/tips/TIP-0018/tip-0018.md
+++ b/tips/TIP-0018/tip-0018.md
@@ -2858,8 +2858,8 @@ are encoded in inputs and outputs respectively.
 | Transitions the foundry | Input with `Foundry ID` | Output with `Foundry ID` |
 | Destroys the foundry    | Input with `Foundry ID` | Empty                    |
 
-- The foundry output must be unlocked like any other output type where the <i>Address Unlock Condition</i> defines an
-  <i>Alias Address</i>, by transitioning the alias in the very same transaction. See section
+- The foundry output must be unlocked like any other output type where the __Address Unlock Condition__ defines an
+  __Alias Address__, by transitioning the alias in the very same transaction. See section
   [alias unlocking](#unlocking-chain-script-locked-outputs) for more details.
 - When the current state of the foundry with `Foundry ID` is empty, it must hold true for `Serial Number` in the next
   state, that:


### PR DESCRIPTION
Fixed the formatting in tip18 as it breaks the docusaurus link afterwards