### PR TITLE
Remove dangling sentence

### DIFF
--- a/tips/TIP-0018/tip-0018.md
+++ b/tips/TIP-0018/tip-0018.md
@@ -1262,14 +1262,11 @@ increases the required storage deposit. ISC is a great example of a higher layer
 #### Tag Feature
 
 A <i>Tag Feature</i> makes it possible to tag outputs with an index, so they can be retrieved through an indexer API not
-only by their address, but also based on the the `Tag`. **The combination of a <i>Tag Feature</i>, a
+only by their address, but also based on the `Tag`. **The combination of a <i>Tag Feature</i>, a
 <i>Metadata Feature</i> and a <i>Sender Feature</i> makes it possible to retrieve data associated to an address and stored
 in outputs that were created by a specific party (`Sender`) for a specific purpose (`Tag`).**
 
 An example use case is voting on the Tangle via the [participation](https://github.com/iota-community/treasury/blob/main/specifications/hornet-participation-plugin.md) plugin.
-
-Storing indexed data in outputs however incurs greater storage deposit for such outputs, because they create look-up
-entries in nodes' databases.
 
 ##### Additional syntactic transaction validation rules:
 - An output with <i>Tag Feature</i> is valid, if and only if 0 < `length(Tag)` ≤


### PR DESCRIPTION
The `Tag` field of a `Tag Feature` is treated as plain data by the protocol. ([`data` field type in TIP-19](https://github.com/iotaledger/tips/blob/main/tips/TIP-0019/tip-0019.md#field-types))