### PR TITLE
Fix token id name

### DIFF
--- a/tips/TIP-0025/core-rest-api.yaml
+++ b/tips/TIP-0025/core-rest-api.yaml
@@ -2222,14 +2222,14 @@ components:
     NativeToken:
       description: A native token and its balance in the output.
       properties:
-        tokenId:
+        id:
           type: string
           description: Hex-encoded identifier with 0x prefix of the native token. Same as foundryId of the controlling foundry.
         amount:
           type: string
           description: Amount of native tokens (up to uint256). Hex-encoded number with 0x prefix.
       required:
-        - tokenId
+        - id
         - amount
 
     Ed25519Address:


### PR DESCRIPTION
In the API its returned like `"nativeTokens":[{"id":"0x08722b1bf4f0295866c8bc75590d83b7422e47739e4b0048126fae45d0b5d330f90200000000","amount":"0x3e8"}]`, so only `id`