### PR TITLE
Fix Unlock Syntactic Validation

### DIFF
--- a/tips/TIP-0018/tip-0018.md
+++ b/tips/TIP-0018/tip-0018.md
@@ -3726,7 +3726,7 @@ always need to be one *Alias Unlock* referencing a greater index.
 
 #### Alias Unlock Syntactic Validation
 
- - It must hold that 0 ≤ `Alias Reference Unlock Index` < `Max Inputs Count`.
+ - It must hold that 0 ≤ `Alias Reference Unlock Index` < `Max Inputs Count - 1`.
 
 #### Alias Unlock Semantic Validation
 
@@ -3786,7 +3786,7 @@ must hold that i > k. Hence, an <i>NFT Unlock</i> can only reference an *Unlock*
 
 #### NFT Unlock Syntactic Validation
 
-- It must hold that 0 ≤ `NFT Reference Unlock Index` < `Max Inputs Count`.
+- It must hold that 0 ≤ `NFT Reference Unlock Index` < `Max Inputs Count - 1`.
 
 #### NFT Unlock Semantic Validation
 


### PR DESCRIPTION
A reference index must be < `Max Inputs Count - 1`, because it otherwise could be a self reference, which is not allowed in the unlocks semantic validation. So no point in allowing that in the syntactic validation of an unlock then in the first place