### PR TITLE
remove Devnet references

### DIFF
--- a/tips/TIP-0031/tip-0031.md
+++ b/tips/TIP-0031/tip-0031.md
@@ -57,9 +57,9 @@ The human-readable encoding of the address is Bech32 (as described in [BIP-0173]
 
 - The **human-readable part** (HRP), which conveys the protocol and distinguishes between the different networks. HRPs are registered in [SLIP-0173]( https://github.com/satoshilabs/slips/blob/master/slip-0173.md):
    - `iota` is the human-readable part for IOTA Mainnet addresses (IOTA tokens)
-   - `atoi` is the human-readable part for IOTA Testnet/Devnet addresses
+   - `atoi` is the human-readable part for IOTA Testnet addresses
   -  `smr` is the human-readable part for Shimmer network addresses (Shimmer tokens)
-  -  `rms` is the human-readable part for Shimmer Testnet/Devnet addresses
+  -  `rms` is the human-readable part for Shimmer Testnet addresses
 - The **separator**, which is always `1`.
 - The **data part**, which consists of the Base32 encoded serialized address and the 6-character checksum.
 


### PR DESCRIPTION
# Description of change

Removed the Devnet reference as we are going with the term Testnet

## Type of change

- Documentation Update
 
## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
